### PR TITLE
BASE-21 - Add ObjectClass.ALL to the Framework constants

### DIFF
--- a/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/operations/AuthenticationImpl.java
+++ b/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/operations/AuthenticationImpl.java
@@ -19,6 +19,7 @@
  * enclosed by brackets [] replaced by your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
  * ====================
+ * Portions Copyrighted 2014 ForgeRock AS.
  */
 package org.identityconnectors.framework.impl.api.local.operations;
 
@@ -51,6 +52,10 @@ public class AuthenticationImpl extends ConnectorAPIOperationRunner implements
             final GuardedString password,
             OperationOptions options) {
         Assertions.nullCheck(objectClass, "objectClass");
+        if (ObjectClass.ALL.equals(objectClass)) {
+            throw new UnsupportedOperationException(
+                    "Operation is not allowed on __ALL__ object class");
+        }
         Assertions.nullCheck(username, "username");
         Assertions.nullCheck(password, "password");
         //cast null as empty

--- a/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/operations/CreateImpl.java
+++ b/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/operations/CreateImpl.java
@@ -19,7 +19,7 @@
  * enclosed by brackets [] replaced by your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
  * ====================
- * Portions Copyrighted 2010-2013 ForgeRock AS.
+ * Portions Copyrighted 2010-2014 ForgeRock AS.
  */
 package org.identityconnectors.framework.impl.api.local.operations;
 
@@ -58,6 +58,10 @@ public class CreateImpl extends ConnectorAPIOperationRunner implements
     public Uid create(final ObjectClass objectClass, final Set<Attribute> createAttributes,
             OperationOptions options) {
         Assertions.nullCheck(objectClass, "objectClass");
+        if (ObjectClass.ALL.equals(objectClass)) {
+            throw new UnsupportedOperationException(
+                    "Operation is not allowed on __ALL__ object class");
+        }
         Assertions.nullCheck(createAttributes, "createAttributes");
         // check to make sure there's not a uid..
         if (AttributeUtil.getUidAttribute(createAttributes) != null) {

--- a/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/operations/DeleteImpl.java
+++ b/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/operations/DeleteImpl.java
@@ -19,6 +19,7 @@
  * enclosed by brackets [] replaced by your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
  * ====================
+ * Portions Copyrighted 2014 ForgeRock AS.
  */
 package org.identityconnectors.framework.impl.api.local.operations;
 
@@ -43,13 +44,17 @@ public class DeleteImpl extends ConnectorAPIOperationRunner implements
     /**
      * Calls the delete method on the Connector side.
      *
-     * @see org.identityconnectors.framework.api.operations.CreateApiOp#create(java.util.Set)
+     * @see org.identityconnectors.framework.api.operations.CreateApiOp#create(org.identityconnectors.framework.common.objects.ObjectClass, java.util.Set, org.identityconnectors.framework.common.objects.OperationOptions)
      */
     @Override
     public void delete(final ObjectClass objectClass,
             final Uid uid,
             OperationOptions options) {
-        Assertions.nullCheck(objectClass, "objClass");
+        Assertions.nullCheck(objectClass, "objectClass");
+        if (ObjectClass.ALL.equals(objectClass)) {
+            throw new UnsupportedOperationException(
+                    "Operation is not allowed on __ALL__ object class");
+        }
         Assertions.nullCheck(uid, "uid");
         //cast null as empty
         if ( options == null ) {

--- a/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/operations/GetImpl.java
+++ b/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/operations/GetImpl.java
@@ -19,7 +19,7 @@
  * enclosed by brackets [] replaced by your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
  * ====================
- * Portions Copyrighted 2010-2013 ForgeRock AS.
+ * Portions Copyrighted 2010-2014 ForgeRock AS.
  */
 package org.identityconnectors.framework.impl.api.local.operations;
 
@@ -54,6 +54,10 @@ public class GetImpl implements GetApiOp {
     @Override
     public ConnectorObject getObject(ObjectClass objectClass, Uid uid, OperationOptions options) {
         Assertions.nullCheck(objectClass, "objectClass");
+        if (ObjectClass.ALL.equals(objectClass)) {
+            throw new UnsupportedOperationException(
+                    "Operation is not allowed on __ALL__ object class");
+        }
         Assertions.nullCheck(uid, "uid");
         // cast null as empty
         if (options == null) {

--- a/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/operations/ResolveUsernameImpl.java
+++ b/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/operations/ResolveUsernameImpl.java
@@ -19,6 +19,7 @@
  * enclosed by brackets [] replaced by your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
  * ====================
+ * Portions Copyrighted 2014 ForgeRock AS.
  */
 package org.identityconnectors.framework.impl.api.local.operations;
 
@@ -47,6 +48,10 @@ public class ResolveUsernameImpl extends ConnectorAPIOperationRunner implements
     public Uid resolveUsername(final ObjectClass objectClass, final String username,
             OperationOptions options) {
         Assertions.nullCheck(objectClass, "objectClass");
+        if (ObjectClass.ALL.equals(objectClass)) {
+            throw new UnsupportedOperationException(
+                    "Operation is not allowed on __ALL__ object class");
+        }
         Assertions.nullCheck(username, "username");
         //cast null as empty
         if ( options == null ) {

--- a/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/operations/SearchImpl.java
+++ b/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/operations/SearchImpl.java
@@ -19,7 +19,7 @@
  * enclosed by brackets [] replaced by your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
  * ====================
- * Portions Copyrighted 2010-2013 ForgeRock AS.
+ * Portions Copyrighted 2010-2014 ForgeRock AS.
  */
 package org.identityconnectors.framework.impl.api.local.operations;
 
@@ -63,6 +63,10 @@ public class SearchImpl extends ConnectorAPIOperationRunner implements SearchApi
     public SearchResult search(ObjectClass objectClass, Filter originalFilter,
             ResultsHandler handler, OperationOptions options) {
         Assertions.nullCheck(objectClass, "objectClass");
+        if (ObjectClass.ALL.equals(objectClass)) {
+            throw new UnsupportedOperationException(
+                    "Operation is not allowed on __ALL__ object class");
+        }
         Assertions.nullCheck(handler, "handler");
         // cast null as empty
         if (options == null) {

--- a/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/operations/UpdateImpl.java
+++ b/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/operations/UpdateImpl.java
@@ -19,7 +19,7 @@
  * enclosed by brackets [] replaced by your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
  * ====================
- * Portions Copyrighted 2010-2013 ForgeRock AS.
+ * Portions Copyrighted 2010-2014 ForgeRock AS.
  */
 package org.identityconnectors.framework.impl.api.local.operations;
 
@@ -237,6 +237,10 @@ public class UpdateImpl extends ConnectorAPIOperationRunner implements
             final Set<Attribute> replaceAttributes, boolean isDelta) {
         Assertions.nullCheck(uid, "uid");
         Assertions.nullCheck(objectClass, "objectClass");
+        if (ObjectClass.ALL.equals(objectClass)) {
+            throw new UnsupportedOperationException(
+                    "Operation is not allowed on __ALL__ object class");
+        }
         Assertions.nullCheck(replaceAttributes, "replaceAttributes");
         // check to make sure there's not a uid..
         if (AttributeUtil.getUidAttribute(replaceAttributes) != null) {

--- a/java/connector-framework-internal/src/test/java/org/identityconnectors/framework/impl/api/ConnectorFacadeTests.java
+++ b/java/connector-framework-internal/src/test/java/org/identityconnectors/framework/impl/api/ConnectorFacadeTests.java
@@ -19,6 +19,7 @@
  * enclosed by brackets [] replaced by your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
  * ====================
+ * Portions Copyrighted 2014 ForgeRock AS.
  */
 package org.identityconnectors.framework.impl.api;
 
@@ -49,6 +50,9 @@ import org.identityconnectors.framework.common.objects.Name;
 import org.identityconnectors.framework.common.objects.ObjectClass;
 import org.identityconnectors.framework.common.objects.ResultsHandler;
 import org.identityconnectors.framework.common.objects.ScriptContextBuilder;
+import org.identityconnectors.framework.common.objects.SyncDelta;
+import org.identityconnectors.framework.common.objects.SyncResultsHandler;
+import org.identityconnectors.framework.common.objects.SyncToken;
 import org.identityconnectors.framework.common.objects.Uid;
 import org.identityconnectors.framework.spi.Configuration;
 import org.identityconnectors.framework.spi.Connector;
@@ -201,6 +205,22 @@ public class ConnectorFacadeTests {
         });
     }
 
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void authenticateAllCallPattern() {
+        testCallPattern(new TestOperationPattern() {
+            @Override
+            public void makeCall(ConnectorFacade facade) {
+                facade.authenticate(ObjectClass.ALL, "dfadf", new GuardedString("fadfkj"
+                        .toCharArray()), null);
+            }
+
+            @Override
+            public void checkCalls(List<Call> calls) {
+                fail("Should not get here..");
+            }
+        });
+    }
+
     @Test
     public void resolveUsernameCallPattern() {
         testCallPattern(new TestOperationPattern() {
@@ -212,6 +232,21 @@ public class ConnectorFacadeTests {
             @Override
             public void checkCalls(List<Call> calls) {
                 assertEquals(calls.remove(0).getMethodName(), "resolveUsername");
+            }
+        });
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void resolveUsernameAllCallPattern() {
+        testCallPattern(new TestOperationPattern() {
+            @Override
+            public void makeCall(ConnectorFacade facade) {
+                facade.resolveUsername(ObjectClass.ALL, "dfadf", null);
+            }
+
+            @Override
+            public void checkCalls(List<Call> calls) {
+                fail("Should not get here..");
             }
         });
     }
@@ -239,6 +274,22 @@ public class ConnectorFacadeTests {
             public void makeCall(ConnectorFacade facade) {
                 Set<Attribute> attrs = new HashSet<Attribute>();
                 facade.create(null, attrs, null);
+            }
+
+            @Override
+            public void checkCalls(List<Call> calls) {
+                fail("Should not get here..");
+            }
+        });
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void createAllCallPattern() {
+        testCallPattern(new TestOperationPattern() {
+            @Override
+            public void makeCall(ConnectorFacade facade) {
+                Set<Attribute> attrs = CollectionUtil.<Attribute> newReadOnlySet();
+                facade.create(ObjectClass.ALL, attrs, null);
             }
 
             @Override
@@ -283,6 +334,23 @@ public class ConnectorFacadeTests {
         });
     }
 
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void updateAllCallPattern() {
+        testCallPattern(new TestOperationPattern() {
+            @Override
+            public void makeCall(ConnectorFacade facade) {
+                Set<Attribute> attrs = new HashSet<Attribute>();
+                attrs.add(AttributeBuilder.build("accountid"));
+                facade.update(ObjectClass.ALL, newUid(0), attrs, null);
+            }
+
+            @Override
+            public void checkCalls(List<Call> calls) {
+                fail("Should not get here..");
+            }
+        });
+    }
+
     @Test
     public void deleteCallPattern() {
         testCallPattern(new TestOperationPattern() {
@@ -294,6 +362,21 @@ public class ConnectorFacadeTests {
             @Override
             public void checkCalls(List<Call> calls) {
                 assertEquals(calls.remove(0).getMethodName(), "delete");
+            }
+        });
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void deleteAllCallPattern() {
+        testCallPattern(new TestOperationPattern() {
+            @Override
+            public void makeCall(ConnectorFacade facade) {
+                facade.delete(ObjectClass.ALL, newUid(0), null);
+            }
+
+            @Override
+            public void checkCalls(List<Call> calls) {
+                fail("Should not get here..");
             }
         });
     }
@@ -322,6 +405,29 @@ public class ConnectorFacadeTests {
         });
     }
 
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void searchAllCallPattern() {
+        testCallPattern(new TestOperationPattern() {
+            @Override
+            public void makeCall(ConnectorFacade facade) {
+                // create an empty results handler..
+                ResultsHandler rh = new ResultsHandler() {
+                    @Override
+                    public boolean handle(ConnectorObject obj) {
+                        return true;
+                    }
+                };
+                // call the search method..
+                facade.search(ObjectClass.ALL, null, rh, null);
+            }
+
+            @Override
+            public void checkCalls(List<Call> calls) {
+                fail("Should not get here..");
+            }
+        });
+    }
+
     @Test
     public void getCallPattern() {
         testCallPattern(new TestOperationPattern() {
@@ -336,6 +442,95 @@ public class ConnectorFacadeTests {
             public void checkCalls(List<Call> calls) {
                 assertEquals(calls.remove(0).getMethodName(), "createFilterTranslator");
                 assertEquals(calls.remove(0).getMethodName(), "executeQuery");
+            }
+        });
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void getAllCallPattern() {
+        testCallPattern(new TestOperationPattern() {
+            @Override
+            public void makeCall(ConnectorFacade facade) {
+                facade.getObject(ObjectClass.ALL, newUid(0), null);
+            }
+
+            @Override
+            public void checkCalls(List<Call> calls) {
+                fail("Should not get here..");
+            }
+        });
+    }
+
+    @Test
+    public void getLatestSyncTokenCallPattern() {
+        testCallPattern(new TestOperationPattern() {
+            @Override
+            public void makeCall(ConnectorFacade facade) {
+                facade.getLatestSyncToken(ObjectClass.ACCOUNT);
+            }
+
+            @Override
+            public void checkCalls(List<Call> calls) {
+                assertEquals(calls.remove(0).getMethodName(), "getLatestSyncToken");
+            }
+        });
+    }
+
+    @Test
+    public void getLatestSyncTokenAllCallPattern() {
+        testCallPattern(new TestOperationPattern() {
+            @Override
+            public void makeCall(ConnectorFacade facade) {
+                facade.getLatestSyncToken(ObjectClass.ALL);
+            }
+
+            @Override
+            public void checkCalls(List<Call> calls) {
+                assertEquals(calls.remove(0).getMethodName(), "getLatestSyncToken");
+            }
+        });
+    }
+
+    @Test
+    public void syncCallPattern() {
+        testCallPattern(new TestOperationPattern() {
+            @Override
+            public void makeCall(ConnectorFacade facade) {
+                // create an empty results handler..
+                // call the search method..
+                facade.sync(ObjectClass.ACCOUNT, new SyncToken(1), new SyncResultsHandler() {
+                    @Override
+                    public boolean handle(SyncDelta delta) {
+                        return true;
+                    }
+                }, null);
+            }
+
+            @Override
+            public void checkCalls(List<Call> calls) {
+                assertEquals(calls.remove(0).getMethodName(), "sync");
+            }
+        });
+    }
+
+    @Test
+    public void syncAllCallPattern() {
+        testCallPattern(new TestOperationPattern() {
+            @Override
+            public void makeCall(ConnectorFacade facade) {
+                // create an empty results handler..
+                // call the search method..
+                facade.sync(ObjectClass.ALL, new SyncToken(1), new SyncResultsHandler() {
+                    @Override
+                    public boolean handle(SyncDelta delta) {
+                        return true;
+                    }
+                }, null);
+            }
+
+            @Override
+            public void checkCalls(List<Call> calls) {
+                assertEquals(calls.remove(0).getMethodName(), "sync");
             }
         });
     }

--- a/java/connector-framework-internal/src/test/java/org/identityconnectors/mockconnector/MockAllOpsConnector.java
+++ b/java/connector-framework-internal/src/test/java/org/identityconnectors/mockconnector/MockAllOpsConnector.java
@@ -19,6 +19,7 @@
  * enclosed by brackets [] replaced by your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
  * ====================
+ * Portions Copyrighted 2014 ForgeRock AS.
  */
 package org.identityconnectors.mockconnector;
 
@@ -30,6 +31,8 @@ import org.identityconnectors.framework.common.objects.ObjectClass;
 import org.identityconnectors.framework.common.objects.OperationOptions;
 import org.identityconnectors.framework.common.objects.ResultsHandler;
 import org.identityconnectors.framework.common.objects.ScriptContext;
+import org.identityconnectors.framework.common.objects.SyncResultsHandler;
+import org.identityconnectors.framework.common.objects.SyncToken;
 import org.identityconnectors.framework.common.objects.Uid;
 import org.identityconnectors.framework.common.objects.filter.AbstractFilterTranslator;
 import org.identityconnectors.framework.common.objects.filter.FilterTranslator;
@@ -40,13 +43,14 @@ import org.identityconnectors.framework.spi.operations.ResolveUsernameOp;
 import org.identityconnectors.framework.spi.operations.ScriptOnConnectorOp;
 import org.identityconnectors.framework.spi.operations.ScriptOnResourceOp;
 import org.identityconnectors.framework.spi.operations.SearchOp;
+import org.identityconnectors.framework.spi.operations.SyncOp;
 import org.identityconnectors.framework.spi.operations.TestOp;
 import org.identityconnectors.framework.spi.operations.UpdateAttributeValuesOp;
 import org.identityconnectors.framework.spi.operations.UpdateOp;
 
 public class MockAllOpsConnector extends MockConnector implements CreateOp, DeleteOp, UpdateOp,
         SearchOp<String>, UpdateAttributeValuesOp, AuthenticateOp, ResolveUsernameOp, TestOp,
-        ScriptOnConnectorOp, ScriptOnResourceOp {
+        ScriptOnConnectorOp, ScriptOnResourceOp , SyncOp {
 
     @Override
     public Object runScriptOnConnector(ScriptContext request, OperationOptions options) {
@@ -135,5 +139,18 @@ public class MockAllOpsConnector extends MockConnector implements CreateOp, Dele
     @Override
     public void test() {
         addCall();
+    }
+
+    @Override
+    public void sync(ObjectClass objectClass, SyncToken token, SyncResultsHandler handler, OperationOptions options) {
+        assert objectClass != null && token != null && handler != null && options != null;
+        addCall(objectClass, token, handler, options);
+    }
+
+    @Override
+    public SyncToken getLatestSyncToken(ObjectClass objectClass) {
+        assert objectClass != null;
+        addCall(objectClass);
+        return new SyncToken(0);
     }
 }

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/ConnectorObject.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/ConnectorObject.java
@@ -19,6 +19,7 @@
  * enclosed by brackets [] replaced by your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
  * ====================
+ * Portions Copyrighted 2014 ForgeRock AS.
  */
 package org.identityconnectors.framework.common.objects;
 
@@ -49,6 +50,9 @@ public final class ConnectorObject {
     public ConnectorObject(ObjectClass objectClass, Set<? extends Attribute> set) {
         if (objectClass == null) {
             throw new IllegalArgumentException("ObjectClass may not be null");
+        }
+        if (ObjectClass.ALL.equals(objectClass)) {
+            throw new IllegalArgumentException("Connector object class can not be type of __ALL__");
         }
         if (set == null || set.size() == 0) {
             throw new IllegalArgumentException("The set can not be null or empty.");

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/ConnectorObjectBuilder.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/ConnectorObjectBuilder.java
@@ -19,6 +19,7 @@
  * enclosed by brackets [] replaced by your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
  * ====================
+ * Portions Copyrighted 2014 ForgeRock AS.
  */
 package org.identityconnectors.framework.common.objects;
 
@@ -81,6 +82,9 @@ public final class ConnectorObjectBuilder {
     // ObjectClass Setter
     // =======================================================================
     public ConnectorObjectBuilder setObjectClass(ObjectClass oclass) {
+        if (ObjectClass.ALL.equals(oclass)) {
+            throw new IllegalArgumentException("Connector object class can not be type of __ALL__");
+        }
         objectClass = oclass;
         return this;
     }

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/ObjectClass.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/ObjectClass.java
@@ -19,6 +19,7 @@
  * enclosed by brackets [] replaced by your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
  * ====================
+ * Portions Copyrighted 2014 ForgeRock AS.
  */
 package org.identityconnectors.framework.common.objects;
 
@@ -54,6 +55,12 @@ public final class ObjectClass {
      */
     public static final String GROUP_NAME = createSpecialName("GROUP");
 
+    /**
+     * This constant defines a specific {@linkplain #getObjectClassValue value
+     * of ObjectClass} that is reserved for {@link ObjectClass#ALL}.
+     */
+    public static final String ALL_NAME = createSpecialName("ALL");
+
     // =======================================================================
     // Create only after all other static initializers
     // =======================================================================
@@ -81,6 +88,17 @@ public final class ObjectClass {
      * <code>ConnectorObject</code> represents a group.
      */
     public static final ObjectClass GROUP = new ObjectClass(GROUP_NAME);
+
+    /**
+     * Represents all collections that contains any object.
+     * <p>
+     * This constant allowed to use in operation
+     * {@link org.identityconnectors.framework.spi.operations.SyncOp#getLatestSyncToken(ObjectClass)}
+     * and
+     * {@link org.identityconnectors.framework.spi.operations.SyncOp#sync(ObjectClass, SyncToken, SyncResultsHandler, OperationOptions)}
+     * any other operation throws {@link UnsupportedOperationException}
+     */
+    public static final ObjectClass ALL = new ObjectClass(ALL_NAME);
 
     private final String type;
 


### PR DESCRIPTION
As result of the discussion on [mailing list](https://groups.google.com/forum/#!topic/connid-dev/A_uE7j6d4Tk) I implemented the ALL ObjectClass and the checks in the operation implementations. 
