### PR TITLE
BASE-28, BASE-32, BASE-53 fix

### DIFF
--- a/dotnet/Framework/CommonObjects.cs
+++ b/dotnet/Framework/CommonObjects.cs
@@ -2036,7 +2036,7 @@ namespace Org.IdentityConnectors.Framework.Common.Objects
         /// <summary>
         /// Determines if this attribute supports multivalue.
         /// </summary>
-        public ConnectorAttributeInfoBuilder SetMultiValue(bool value)
+        public ConnectorAttributeInfoBuilder SetMultiValued(bool value)
         {
             SetFlag(ConnectorAttributeInfo.Flags.MULTIVALUED, value);
             return this;

--- a/dotnet/Framework/CommonObjectsFilter.cs
+++ b/dotnet/Framework/CommonObjectsFilter.cs
@@ -885,6 +885,17 @@ namespace Org.IdentityConnectors.Framework.Common.Objects.Filters
         }
 
         /// <summary>
+        /// Name of the attribute to find in the <seealso cref="ConnectorObject"/>.
+        /// </summary>
+        public string Name
+        {
+            get
+            {
+                return GetAttribute().Name;
+            }
+        }
+
+        /// <summary>
         /// Determines if the attribute provided is present in the
         /// <see cref="ConnectorObject" />.
         /// </summary>

--- a/dotnet/Framework/Spi.cs
+++ b/dotnet/Framework/Spi.cs
@@ -103,8 +103,8 @@ namespace Org.IdentityConnectors.Framework.Spi
     /// </para>
     /// <para>  
     /// Each property corresponds to two entries in a resource named <code>Messages</code>:
-    /// <code>[Property].display</code> and <code>[Property].help</code>. For example,
-    /// <code>hostname.help</code> and <code>hostname.display</code> would be the keys
+    /// <code>display_[Property]</code> and <code>help_[Property]</code>. For example,
+    /// <code>help_hostname</code> and <code>display_helphostname</code> would be the keys
     /// corresponding to a <code>hostname</code> property. The <code>display</code> message is the display
     /// name of the property and can be used to display the property in a view. The <code>help</code>
     /// message holds the description of the property. The names of the two keys can be overridden

--- a/dotnet/FrameworkInternal/ApiLocal.cs
+++ b/dotnet/FrameworkInternal/ApiLocal.cs
@@ -280,9 +280,9 @@ namespace Org.IdentityConnectors.Framework.Impl.Api.Local
                     GetPropertyOptions(desc);
                 // use the options to set internal properties..
                 int order = 0;
-                String helpKey = name + ".help";
-                String displKey = name + ".display";
-                string grpKey = name + ".group";
+                String helpKey = "help_" + name;
+                String displKey = "display_" +name;
+                string grpKey = "group_" + name;
                 bool confidential = false;
                 bool required = false;
                 if (options != null)
@@ -533,6 +533,10 @@ namespace Org.IdentityConnectors.Framework.Impl.Api.Local
                         (ConnectorClassAttribute)attributes[0];
                     LocalConnectorInfoImpl info =
                         CreateConnectorInfo(assembly, type, attribute);
+                    UriBuilder uri = new UriBuilder(assembly.CodeBase);
+                    Trace.TraceInformation("Add ConnectorInfo {0} to Local Connector Info Manager from {1}",
+                                info.ConnectorKey, Uri.UnescapeDataString(uri.Path));
+
                     rv.Add(info);
                 }
             }

--- a/dotnet/TestBundles/TestBundleV1/Messages.es-ES.resx
+++ b/dotnet/TestBundles/TestBundleV1/Messages.es-ES.resx
@@ -117,13 +117,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="tstField.display" xml:space="preserve">
+  <data name="display_tstField" xml:space="preserve">
     <value>tstField.display_es-ES</value>
   </data>
-  <data name="tstField.help" xml:space="preserve">
+  <data name="help_tstField" xml:space="preserve">
     <value>tstField.help_es-ES</value>
   </data>
-  <data name="tstField.group" xml:space="preserve">
+  <data name="group_tstField" xml:space="preserve">
     <value>tstField.group_es-ES</value>
   </data>
 </root>

--- a/dotnet/TestBundles/TestBundleV1/Messages.es.resx
+++ b/dotnet/TestBundles/TestBundleV1/Messages.es.resx
@@ -117,13 +117,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="tstField.help" xml:space="preserve">
+  <data name="help_tstField" xml:space="preserve">
     <value>tstField.help_es</value>
   </data>
-  <data name="tstField.display" xml:space="preserve">
+  <data name="display_tstField" xml:space="preserve">
     <value>tstField.display_es</value>
   </data>
-  <data name="tstField.group" xml:space="preserve">
+  <data name="group_tstField" xml:space="preserve">
     <value>tstField.group_es</value>
   </data>
 </root>

--- a/dotnet/TestBundles/TestBundleV1/Messages.resx
+++ b/dotnet/TestBundles/TestBundleV1/Messages.resx
@@ -117,13 +117,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="tstField.help" xml:space="preserve">
+  <data name="help_tstField" xml:space="preserve">
     <value>Help for test field.</value>
   </data>
-  <data name="tstField.display" xml:space="preserve">
+  <data name="display_tstField" xml:space="preserve">
     <value>Display for test field.</value>
   </data>
-  <data name="tstField.group" xml:space="preserve">
+  <data name="group_tstField" xml:space="preserve">
     <value>Group for test field.</value>
   </data>
 </root>

--- a/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/LocalConnectorInfoManagerImpl.java
+++ b/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/LocalConnectorInfoManagerImpl.java
@@ -255,8 +255,8 @@ public class LocalConnectorInfoManagerImpl implements ConnectorInfoManager {
                         // it might be from a bundle
                         // fragment ( a bundle only included by other bundles ).
                         // However, we should definitely warn
-                        LOG.warn(
-                                e,
+                        LOG.info(LOG.isOk() ?
+                                 e : null,
                                 "Unable to load class {0} from bundle {1}. Class will be ignored and will not be listed in list of connectors.",
                                 className, bundleInfo.getOriginalLocation());
                     }
@@ -283,12 +283,12 @@ public class LocalConnectorInfoManagerImpl implements ConnectorInfoManager {
                         LOG.info("Add ConnectorInfo {0} to Local Connector Info Manager from {1}",
                                 info.getConnectorKey(), bundleInfo.getOriginalLocation());
                     } catch (final NoClassDefFoundError e) {
-                        LOG.warn(LOG.isOk() ?
+                        LOG.info(LOG.isOk() ?
                                 e : null,
                                 "Unable to load configuration class of connector {0} from bundle {1}. Class will be ignored and will not be listed in list of connectors.",
                                 connectorClass, bundleInfo.getOriginalLocation());
                     } catch (final TypeNotPresentException e) {
-                        LOG.warn(LOG.isOk() ?
+                        LOG.info(LOG.isOk() ?
                                  e : null,
                                 "Unable to load configuration class of connector {0} from bundle {1}. Class will be ignored and will not be listed in list of connectors.",
                                 connectorClass, bundleInfo.getOriginalLocation());

--- a/java/slf4j-logging/src/main/java/org/identityconnectors/common/logging/slf4j/SLF4JLog.java
+++ b/java/slf4j-logging/src/main/java/org/identityconnectors/common/logging/slf4j/SLF4JLog.java
@@ -58,7 +58,8 @@ public class SLF4JLog implements LogSpi {
                 ((LocationAwareLogger) logger).log(null, clazz.getName(), getLogLevel(level), message, null, ex);
             } else {
                 //StringBuilder sb = new StringBuilder(METHOD).append(methodName).append("\t").append(message);
-                StringBuilder sb = new StringBuilder(message).append('\t').append(METHOD).append(methodName);
+                StringBuilder sb =
+                        new StringBuilder(null == message ? "" : message).append('\t').append(METHOD).append(methodName);
                 ((LocationAwareLogger) logger).log(null, clazz.getName(), getLogLevel(level), sb
                         .toString(), null, ex);
             }
@@ -67,7 +68,10 @@ public class SLF4JLog implements LogSpi {
             if (StringUtil.isNotBlank(methodName)){
                 sb.append(methodName).append('\t');
             }
-            sb.append(MESSAGE).append(message);
+            sb.append(MESSAGE);
+            if (null != message) {
+                sb.append(message);
+            }
             // uses different call if the exception is not null..
             if (Level.OK.equals(level)) {
                 if (ex == null) {


### PR DESCRIPTION
BASE-32 - Typo error in the name of SetMultiValue(d) method
BASE-28 - Missing Name getter of Filter from c# code
BASE-35 - The SLF4JLog throws NPE when the message is null
Additional fix the change of log level in Local Connector Info Manager
to make less noise in log file and the default group, display and help
key is without '.' that's incompatible with Resource View naming.
