### PR TITLE
Fixing connector pool bug

### DIFF
--- a/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/ObjectPool.java
+++ b/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/ObjectPool.java
@@ -20,6 +20,7 @@
  * "Portions Copyrighted [year] [name of copyright owner]"
  * ====================
  * Portions Copyrighted 2010-2013 ForgeRock AS.
+ * Portions Copyrighted 2015 Evolveum
  */
 
 package org.identityconnectors.framework.impl.api.local;
@@ -287,9 +288,17 @@ public class ObjectPool<T> {
             try {
                 do {
                     if (totalPermit.tryAcquire()) {
-                        // If the pool is empty and there are available permits
-                        // then create a new instance.
-                        return makeObject();
+                    	try {
+	                        // If the pool is empty and there are available permits
+	                        // then create a new instance.
+	                        return makeObject();
+                    	} catch (RuntimeException e) {
+                    		totalPermit.release();
+                    		throw e;
+                    	} catch (Error e) {
+                    		totalPermit.release();
+                    		throw e;
+                    	}
                     } else {
                         // Wait for permit or object to became available
                         try {


### PR DESCRIPTION
Fixing connector pool bug: the pool will become stuck if connector.init() method fails.