### PR TITLE
nativeName in AttributeInfo (BASE-47)

### DIFF
--- a/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/serializer/CommonObjectHandlers.java
+++ b/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/serializer/CommonObjectHandlers.java
@@ -366,6 +366,7 @@ class CommonObjectHandlers {
                     }
                 }
                 builder.setFlags(flags);
+                builder.setNativeName(decoder.readStringField("nativeName", null));
                 return builder.build();
             }
 
@@ -377,6 +378,7 @@ class CommonObjectHandlers {
                 for (Flags flag : flags) {
                     encoder.writeObjectContents(flag);
                 }
+                encoder.writeStringField("nativeName", val.getNativeName());
             }
         });
 

--- a/java/connector-framework-internal/src/main/resources/org/identityconnectors/framework/impl/serializer/xml/connectors.dtd
+++ b/java/connector-framework-internal/src/main/resources/org/identityconnectors/framework/impl/serializer/xml/connectors.dtd
@@ -332,6 +332,7 @@ OperationOptionInfo | SyncDeltaType | SyncToken | SyncDelta | QualifiedUid
 <!ATTLIST AttributeInfo
    name CDATA #REQUIRED
    type CDATA #REQUIRED
+   nativeName CDATA #IMPLIED
 >
 <!ELEMENT AttributeInfoFlag EMPTY>
 <!ATTLIST AttributeInfoFlag

--- a/java/connector-framework-internal/src/test/java/org/identityconnectors/framework/impl/serializer/ObjectSerializationTests.java
+++ b/java/connector-framework-internal/src/test/java/org/identityconnectors/framework/impl/serializer/ObjectSerializationTests.java
@@ -585,6 +585,7 @@ public class ObjectSerializationTests {
         builder.setCreateable(true);
         builder.setMultiValued(true);
         builder.setUpdateable(false);
+        builder.setNativeName("FOOFOO");
         builder.setReturnedByDefault(false);
         AttributeInfo v1 = builder.build();
         AttributeInfo v2 = (AttributeInfo)cloneObject(v1);
@@ -638,6 +639,7 @@ public class ObjectSerializationTests {
         builder.setReadable(true);
         builder.setCreateable(true);
         builder.setMultiValued(true);
+        builder.setNativeName("FOOFOO");
         ObjectClassInfoBuilder obld = new ObjectClassInfoBuilder();
         obld.addAttributeInfo(builder.build());
         obld.setContainer(true);

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/AttributeInfo.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/AttributeInfo.java
@@ -52,6 +52,7 @@ public final class AttributeInfo {
 
     private final String name;
     private final Class<?> type;
+    private final String nativeName;
     private final Set<Flags> flags;
 
     /**
@@ -70,8 +71,12 @@ public final class AttributeInfo {
     public static enum Flags {
         REQUIRED, MULTIVALUED, NOT_CREATABLE, NOT_UPDATEABLE, NOT_READABLE, NOT_RETURNED_BY_DEFAULT
     }
-
+    
     AttributeInfo(final String name, final Class<?> type, final Set<Flags> flags) {
+    	this(name, type, null, flags);
+    }
+
+    AttributeInfo(final String name, final Class<?> type, final String nativeName, final Set<Flags> flags) {
         if (StringUtil.isBlank(name)) {
             throw new IllegalStateException("Name must not be blank!");
         }
@@ -86,6 +91,7 @@ public final class AttributeInfo {
         FrameworkUtil.checkAttributeType(type);
         this.name = name;
         this.type = type;
+        this.nativeName = nativeName;
         this.flags = Collections.unmodifiableSet(EnumSet.copyOf(flags));
         if (!isReadable() && isReturnedByDefault()) {
             throw new IllegalArgumentException(
@@ -96,9 +102,11 @@ public final class AttributeInfo {
     }
 
     /**
-     * The native name of the attribute.
+     * The name of the attribute. This the attribute name as it is known by the
+     * framework. It may be derived from the native attribute name. Or it may
+     * be one of the special names such as __NAME__ or __PASSWORD__.
      *
-     * @return the native name of the attribute its describing.
+     * @return the name of the attribute its describing.
      */
     public String getName() {
         return name;
@@ -113,8 +121,22 @@ public final class AttributeInfo {
     public Class<?> getType() {
         return type;
     }
-
+    
     /**
+     * The native name of the attribute. This is the attribute name as it is
+     * known by the resource. It is especially useful for attributes with
+     * special names such as __NAME__ or __PASSWORD__. In this case the
+     * nativeName will contain the real name of the attribute.
+     * The nativeName may be null. In such a case it is assumed that the
+     * native name is the same as name.
+     *
+     * @return the native name of the attribute its describing.
+     */
+    public String getNativeName() {
+		return nativeName;
+	}
+
+	/**
      * Returns the set of flags associated with the attribute.
      *
      * @return the set of flags associated with the attribute

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/AttributeInfoBuilder.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/AttributeInfoBuilder.java
@@ -156,9 +156,6 @@ public final class AttributeInfoBuilder {
      *            native name of the {@link AttributeInfo} object.
      */
     public AttributeInfoBuilder setNativeName(final String nativeName) {
-        if (StringUtil.isBlank(nativeName)) {
-            throw new IllegalArgumentException("Argument must not be blank.");
-        }
         this.nativeName = nativeName;
         return this;
     }

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/AttributeInfoBuilder.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/AttributeInfoBuilder.java
@@ -47,6 +47,7 @@ public final class AttributeInfoBuilder {
 
     private String name;
     private Class<?> type;
+    private String nativeName;
     private final EnumSet<Flags> flags;
 
     /**
@@ -116,7 +117,7 @@ public final class AttributeInfoBuilder {
      * @return {@link AttributeInfo} based on the properties set.
      */
     public AttributeInfo build() {
-        return new AttributeInfo(name, type, flags);
+        return new AttributeInfo(name, type, nativeName, flags);
     }
 
     /**
@@ -145,6 +146,20 @@ public final class AttributeInfoBuilder {
     public AttributeInfoBuilder setType(final Class<?> value) {
         FrameworkUtil.checkAttributeType(value);
         type = value;
+        return this;
+    }
+    
+    /**
+     * Sets the native name of the {@link AttributeInfo} object.
+     *
+     * @param nativeName
+     *            native name of the {@link AttributeInfo} object.
+     */
+    public AttributeInfoBuilder setNativeName(final String nativeName) {
+        if (StringUtil.isBlank(nativeName)) {
+            throw new IllegalArgumentException("Argument must not be blank.");
+        }
+        this.nativeName = nativeName;
         return this;
     }
 


### PR DESCRIPTION
Ability to specify (optional) native attribute name in the schema. This is the attribute name as the resource knows it. It is especially useful for special attributes such as _NAME_. The nativeName can be used by the IDM to display real attribute names in the GUI.

This is implementation for the Java framework. .NET implementation is still TODO.