### PR TITLE
Support for attribute subtypes in AttributeInfo (BASE-54)

### DIFF
--- a/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/serializer/CommonObjectHandlers.java
+++ b/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/serializer/CommonObjectHandlers.java
@@ -20,7 +20,7 @@
  * "Portions Copyrighted [year] [name of copyright owner]"
  * ====================
  * Portions Copyrighted 2010-2013 ForgeRock AS.
- * Portions Copyrighted 2015 Evolveum
+ * Portions Copyrighted 2015-2016 Evolveum
  */
 package org.identityconnectors.framework.impl.serializer;
 
@@ -396,6 +396,7 @@ class CommonObjectHandlers {
                 }
                 builder.setFlags(flags);
                 builder.setNativeName(decoder.readStringField("nativeName", null));
+                builder.setSubtype(decoder.readStringField("subtype", null));
                 return builder.build();
             }
 
@@ -409,6 +410,7 @@ class CommonObjectHandlers {
                     encoder.writeObjectContents(flag);
                 }
                 encoder.writeStringField("nativeName", val.getNativeName());
+                encoder.writeStringField("subtype", val.getSubtype());
             }
         });
 

--- a/java/connector-framework-internal/src/main/resources/org/identityconnectors/framework/impl/serializer/xml/connectors.dtd
+++ b/java/connector-framework-internal/src/main/resources/org/identityconnectors/framework/impl/serializer/xml/connectors.dtd
@@ -23,7 +23,7 @@
     "Portions Copyrighted [year] [name of copyright owner]"
     ====================
     Portions Copyrighted 2010-2014 ForgeRock AS.
-    Portions Copyrighted 2015 Evolveum
+    Portions Copyrighted 2015-2016 Evolveum
 
 -->
 
@@ -334,6 +334,7 @@ OperationOptionInfo | SyncDeltaType | SyncToken | SyncDelta | QualifiedUid
    name CDATA #REQUIRED
    type CDATA #REQUIRED
    nativeName CDATA #IMPLIED
+   subtype CDATA #IMPLIED
 >
 <!ELEMENT AttributeInfoFlag EMPTY>
 <!ATTLIST AttributeInfoFlag

--- a/java/connector-framework-internal/src/test/java/org/identityconnectors/framework/impl/serializer/ObjectSerializationTests.java
+++ b/java/connector-framework-internal/src/test/java/org/identityconnectors/framework/impl/serializer/ObjectSerializationTests.java
@@ -20,7 +20,7 @@
  * "Portions Copyrighted [year] [name of copyright owner]"
  * ====================
  * Portions Copyrighted 2010-2014 ForgeRock AS.
- * Portions Copyrighted 2015 Evolveum
+ * Portions Copyrighted 2015-2016 Evolveum
  */
 
 package org.identityconnectors.framework.impl.serializer;
@@ -587,12 +587,14 @@ public class ObjectSerializationTests {
         builder.setMultiValued(true);
         builder.setUpdateable(false);
         builder.setNativeName("FOOFOO");
+        builder.setSubtype(AttributeInfo.Subtypes.STRING_CASE_IGNORE);
         builder.setReturnedByDefault(false);
         AttributeInfo v1 = builder.build();
         AttributeInfo v2 = (AttributeInfo)cloneObject(v1);
         assertEquals(v1,v2);
         assertEquals("foo", v2.getName());
         assertEquals(String.class, v2.getType());
+        assertEquals(AttributeInfo.Subtypes.STRING_CASE_IGNORE.toString(), v2.getSubtype());
         assertTrue(v2.isMultiValued());
         assertTrue(v2.isReadable());
         assertTrue(v2.isRequired());

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/AttributeInfo.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/AttributeInfo.java
@@ -19,6 +19,7 @@
  * enclosed by brackets [] replaced by your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
  * ====================
+ * Portions Copyrighted 2015-2016 Evolveum
  */
 package org.identityconnectors.framework.common.objects;
 
@@ -52,6 +53,7 @@ public final class AttributeInfo {
 
     private final String name;
     private final Class<?> type;
+    private final String subtype;
     private final String nativeName;
     private final Set<Flags> flags;
 
@@ -72,11 +74,57 @@ public final class AttributeInfo {
         REQUIRED, MULTIVALUED, NOT_CREATABLE, NOT_UPDATEABLE, NOT_READABLE, NOT_RETURNED_BY_DEFAULT
     }
     
+    /**
+     * Enumeration of pre-defined attribute subtypes.
+     */
+    public static enum Subtypes {
+    	/**
+    	 * Case-ignore (case-insensitive) string.
+    	 */
+    	STRING_CASE_IGNORE(AttributeUtil.createSpecialName("STRING_CASE_IGNORE")),
+    	
+    	/**
+    	 * Unique Resource Identifier (RFC 3986)
+    	 */
+    	STRING_URI(AttributeUtil.createSpecialName("STRING_URI")),
+    	
+    	/**
+    	 * LDAP Distinguished Name (RFC 4511)
+    	 */
+    	STRING_LDAP_DN(AttributeUtil.createSpecialName("STRING_LDAP_DN")),
+    	
+    	/**
+    	 * Universally unique identifier (UUID)
+    	 */
+    	STRING_UUID(AttributeUtil.createSpecialName("STRING_UUID")),
+    	
+    	/**
+    	 * XML-formatted string (https://www.w3.org/TR/REC-xml/)
+    	 */
+    	STRING_XML(AttributeUtil.createSpecialName("STRING_XML")),
+    	
+    	/**
+    	 * JSON-formatted string
+    	 */
+    	STRING_JSON(AttributeUtil.createSpecialName("STRING_JSON"));
+    	
+    	private final String value;
+
+		private Subtypes(String value) {
+			this.value = value;
+		}
+    	
+    	@Override
+    	public String toString() {
+    		return value;
+    	}
+    }
+    
     AttributeInfo(final String name, final Class<?> type, final Set<Flags> flags) {
-    	this(name, type, null, flags);
+    	this(name, type, null, null, flags);
     }
 
-    AttributeInfo(final String name, final Class<?> type, final String nativeName, final Set<Flags> flags) {
+    AttributeInfo(final String name, final Class<?> type, final String subtype, final String nativeName, final Set<Flags> flags) {
         if (StringUtil.isBlank(name)) {
             throw new IllegalStateException("Name must not be blank!");
         }
@@ -91,6 +139,7 @@ public final class AttributeInfo {
         FrameworkUtil.checkAttributeType(type);
         this.name = name;
         this.type = type;
+        this.subtype = subtype;
         this.nativeName = nativeName;
         this.flags = Collections.unmodifiableSet(EnumSet.copyOf(flags));
         if (!isReadable() && isReturnedByDefault()) {
@@ -123,6 +172,23 @@ public final class AttributeInfo {
     }
     
     /**
+     * Optional subtype of the attribute. This defines a subformat or provides
+     * more specific definition what the attribute contains. E.g. it may define
+     * that the attribute contains case-insensitive string, URL, LDAP distinguished
+     * name and so on.
+     * 
+     * The subtype may contain one of the pre-defined subtypes 
+     * (a value form the Subtype enumeration). The subtype may also contain an URI
+     * that specifies a custom subtype that the connector recognizes and it is not
+     * defined in the pre-defined subtype enumeration.
+     * 
+     * @return attribute subtype.
+     */
+    public String getSubtype() {
+		return subtype;
+	}
+
+	/**
      * The native name of the attribute. This is the attribute name as it is
      * known by the resource. It is especially useful for attributes with
      * special names such as __NAME__ or __PASSWORD__. In this case the

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/AttributeInfoBuilder.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/AttributeInfoBuilder.java
@@ -20,6 +20,7 @@
  * "Portions Copyrighted [year] [name of copyright owner]"
  * ====================
  * Portions Copyrighted 2014 ForgeRock AS.
+ * Portions Copyrighted 2015-2016 Evolveum
  */
 package org.identityconnectors.framework.common.objects;
 
@@ -47,6 +48,7 @@ public final class AttributeInfoBuilder {
 
     private String name;
     private Class<?> type;
+    private String subtype;
     private String nativeName;
     private final EnumSet<Flags> flags;
 
@@ -117,7 +119,7 @@ public final class AttributeInfoBuilder {
      * @return {@link AttributeInfo} based on the properties set.
      */
     public AttributeInfo build() {
-        return new AttributeInfo(name, type, nativeName, flags);
+        return new AttributeInfo(name, type, subtype, nativeName, flags);
     }
 
     /**
@@ -150,6 +152,32 @@ public final class AttributeInfoBuilder {
     }
     
     /**
+     * Optional subtype of the attribute. This defines a subformat or provides
+     * more specific definition what the attribute contains. E.g. it may define
+     * that the attribute contains case-insensitive string, URL, LDAP distinguished
+     * name and so on.
+     * 
+     * The subtype may contain one of the pre-defined subtypes 
+     * (a value form the Subtype enumeration). The subtype may also contain an URI
+     * that specifies a custom subtype that the connector recognizes and it is not
+     * defined in the pre-defined subtype enumeration.
+     * 
+     * See {@link AttributeInfo#Subtypes} for the list of pre-defined subtypes.
+     * 
+     * @param subtype
+     * 			subtype for an {@link Attribute}'s value.
+     */
+    public AttributeInfoBuilder setSubtype(String subtype) {
+		this.subtype = subtype;
+		return this;
+	}
+    
+    public AttributeInfoBuilder setSubtype(AttributeInfo.Subtypes subtype) {
+		this.subtype = subtype.toString();
+		return this;
+	}
+
+	/**
      * Sets the native name of the {@link AttributeInfo} object.
      *
      * @param nativeName


### PR DESCRIPTION
I run out of patience to specify caseIgnore, DN and UUID matching rules all the time over and over again. So I just implemented this feature.

The use of enum and __VALUES_LIKE_THIS__ may seem unusual. But I wanted to maintain the existing look and feel of ConnId.