### PR TITLE
[BASE-84] Service config and Missing EXEC script library 

### DIFF
--- a/java/connector-server-zip/src/main/resources/bin/ConnectorServer.bat
+++ b/java/connector-server-zip/src/main/resources/bin/ConnectorServer.bat
@@ -79,6 +79,7 @@ set CP=%CP%;lib\framework\slf4j-api.jar
 set CP=%CP%;lib\framework\slf4j-logging.jar
 set CP=%CP%;lib\framework\logback-core.jar
 set CP=%CP%;lib\framework\logback-classic.jar
+set CP=%CP%;lib\framework\jul-to-slf4j.jar
 
 echo %CP%
 

--- a/java/connector-server-zip/src/main/resources/bin/ConnectorServer.sh
+++ b/java/connector-server-zip/src/main/resources/bin/ConnectorServer.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # ====================
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.

--- a/java/connector-server-zip/src/main/resources/bin/java-connector-server.service
+++ b/java/connector-server-zip/src/main/resources/bin/java-connector-server.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Java Connector Server Service
+[Service]
+User=connid-server
+WorkingDirectory=/opt/connid-connector-server/
+ExecStart=/opt/connid-connector-server/./bin/ConnectorServer.sh -run -properties /opt/connid-connector-server/conf/connectorserver.properties
+SuccessExitStatus=143
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Hello, just some small change which fixes the .bat connector server script and also a small improvement for service execution. 
- Added lib definition in .bat file which was missing for correct script execution 
- Added Missing shebang in .sh script
- I have added a daemon config example. 