### PR TITLE
Uid.nameHint serialization fix (BASE-87)

### DIFF
--- a/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/serializer/CommonObjectHandlers.java
+++ b/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/serializer/CommonObjectHandlers.java
@@ -54,7 +54,6 @@ import org.identityconnectors.framework.common.exceptions.RetryableException;
 import org.identityconnectors.framework.common.exceptions.UnknownUidException;
 import org.identityconnectors.framework.common.objects.*;
 import org.identityconnectors.framework.common.objects.AttributeInfo.Flags;
-import org.identityconnectors.framework.common.objects.AttributeInfo.Flags;
 import org.identityconnectors.framework.impl.api.remote.RemoteWrappedException;
 
 /**
@@ -579,12 +578,11 @@ class CommonObjectHandlers {
                 final String val = decoder.readStringField("uid", null);
                 final String revision = decoder.readStringField("revision", null);
                 final Name nameHint = (Name) decoder.readObjectField("nameHint", Name.class, null);
-                if (null == revision && null == nameHint) {
-                    return new Uid(val);
-                } else if (null == revision && null != nameHint) {
+                // revision parameter is not-null checked, nameHint is nullable
+                if (revision == null) {
                     return new Uid(val, nameHint);
                 } else {
-                    return new Uid(val, revision);
+                    return new Uid(val, revision, nameHint);
                 }
             }
 
@@ -593,6 +591,7 @@ class CommonObjectHandlers {
                 final Uid val = (Uid) object;
                 encoder.writeStringField("uid", val.getUidValue());
                 encoder.writeStringField("revision", val.getRevision());
+                encoder.writeObjectField("nameHint", val.getNameHint(), true);
             }
         });
 

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/Attribute.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/Attribute.java
@@ -174,7 +174,7 @@ public class Attribute {
     // Object Overrides
     // ===================================================================
     @Override
-    public final int hashCode() {
+    public int hashCode() {
         return nameHashCode(name);
     }
 
@@ -192,11 +192,11 @@ public class Attribute {
     }
 
     protected void extendToStringMap(final Map<String, Object> map) {
-        // Nothing to do here. Just for use in sublcasses.
+        // Nothing to do here. Just for use in subclasses.
     }
 
     @Override
-    public final boolean equals(Object obj) {
+    public boolean equals(Object obj) {
         // test identity
         if (this == obj) {
             return true;

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/AttributeDelta.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/AttributeDelta.java
@@ -19,6 +19,7 @@
  * enclosed by brackets [] replaced by your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
  * ====================
+ * Portions Copyrighted 2022 Evolveum
  */
 package org.identityconnectors.framework.common.objects;
 
@@ -145,7 +146,7 @@ public class AttributeDelta {
     }
 
     @Override
-    public final int hashCode() {
+    public int hashCode() {
         return nameHashCode(name);
     }
 
@@ -165,11 +166,11 @@ public class AttributeDelta {
     }
 
     protected void extendToStringMap(final Map<String, Object> map) {
-        // Nothing to do here. Just for use in sublcasses.
+        // Nothing to do here. Just for use in subclasses.
     }
 
     @Override
-    public final boolean equals(Object obj) {
+    public boolean equals(Object obj) {
         // test identity
         if (this == obj) {
             return true;

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/Uid.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/Uid.java
@@ -20,11 +20,12 @@
  * "Portions Copyrighted [year] [name of copyright owner]"
  * ====================
  * Portions Copyrighted 2010-2013 ForgeRock AS.
- * Portions Copyrighted 2016 Evolveum
+ * Portions Copyrighted 2016-2022 Evolveum
  */
 package org.identityconnectors.framework.common.objects;
 
 import java.util.Map;
+import java.util.Objects;
 
 import org.identityconnectors.common.CollectionUtil;
 import org.identityconnectors.common.StringUtil;
@@ -181,4 +182,24 @@ public final class Uid extends Attribute {
         }
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        Uid uid = (Uid) o;
+        return Objects.equals(revision, uid.revision)
+                && Objects.equals(nameHint, uid.nameHint);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), revision, nameHint);
+    }
 }


### PR DESCRIPTION
Core of the fix is added line 594 in CommonObjectHandler: encoder.writeObjectField("nameHint"...
This should have been indicated by tests, but wasn't because Uid ignored these fields in equals method - this is fixed as well.