### PR TITLE
BASE-88: introduced Attribute#attributeEquals() which ignores subclasses

### DIFF
--- a/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/operations/UpdateDeltaImpl.java
+++ b/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/operations/UpdateDeltaImpl.java
@@ -311,7 +311,7 @@ public class UpdateDeltaImpl extends ConnectorAPIOperationRunner implements Upda
             }
 
             Set<AttributeDelta> sideEffectAttributesDelta = new HashSet<>();
-            if (!uid.equals(ret)) {
+            if (!uid.attributeEquals(ret)) {
                 sideEffectAttributesDelta.add(AttributeDeltaBuilder.build(Uid.NAME, ret.getValue()));
             }
 

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/Attribute.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/Attribute.java
@@ -197,6 +197,15 @@ public class Attribute {
 
     @Override
     public boolean equals(Object obj) {
+        return attributeEquals(obj);
+    }
+
+    /**
+     * Business-level equals that checks name, value and completeness.
+     * For {@link Attribute} it is the same as {@link #equals(Object)},
+     * but may ignore fields in subclasses.
+     */
+    public final boolean attributeEquals(Object obj) {
         // test identity
         if (this == obj) {
             return true;

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/SyncDelta.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/SyncDelta.java
@@ -75,7 +75,7 @@ public final class SyncDelta {
         }
 
         // if object not null, make sure its Uid matches
-        if (object != null && !uid.equals(object.getUid())) {
+        if (object != null && !uid.attributeEquals(object.getUid())) {
             throw new IllegalArgumentException("Uid does not match that of the object.");
         }
         if (object != null && !objectClass.equals(object.getObjectClass())) {

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/filter/EqualsFilter.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/filter/EqualsFilter.java
@@ -66,7 +66,7 @@ public final class EqualsFilter extends AttributeFilter {
         Attribute thisAttr = getAttribute();
         Attribute attr = obj.getAttributeByName(thisAttr.getName());
         if (attr != null) {
-            ret = thisAttr.equals(attr);
+            ret = thisAttr.attributeEquals(attr);
         } else if (thisAttr.getValue() == null) {
             ret = true;
         }

--- a/java/connector-framework/src/test/java/org/identityconnectors/framework/common/objects/FilterBuilderTests.java
+++ b/java/connector-framework/src/test/java/org/identityconnectors/framework/common/objects/FilterBuilderTests.java
@@ -69,6 +69,32 @@ public class FilterBuilderTests {
         assertFalse(filter.accept(bld.build()));
     }
 
+    @Test
+    public void equalsFilterUid() {
+        Uid uid = new Uid("uid-val");
+        Filter filter = FilterBuilder.equalTo(uid);
+
+        assertTrue(filter.accept(
+                new ConnectorObjectBuilder()
+                        .setUid(new Uid("uid-val"))
+                        .setName("ignored")
+                        .build()));
+
+        // equals filter considers only attribute name+value, not nameHint for Uid
+        assertTrue(filter.accept(
+                new ConnectorObjectBuilder()
+                        .setUid(new Uid("uid-val", "name-hint"))
+                        .setName("ignored")
+                        .build()));
+
+        // equals filter considers only attribute name+value, not revision for Uid
+        assertTrue(filter.accept(
+                new ConnectorObjectBuilder()
+                        .setUid(new Uid("uid-val", "revision", null))
+                        .setName("ignored")
+                        .build()));
+    }
+
     // =======================================================================
     // Comparable..
     // =======================================================================


### PR DESCRIPTION
This works like original equals which is more "business-level" equals. This version is used in equality checks where only Attribute fields are important (name/value/attributeValueCompleteness). The low level equals is still used on other places (e.g. other equals).

Note: This equals duality is similar to BigDecimal equals/compare usage. In BigDecimal too, equals is low-level and not for "business value" equality checks.