### PR TITLE
[BASE-89] Add ANY_OBJECT special object class

### DIFF
--- a/dotnet/Framework/CommonObjects.cs
+++ b/dotnet/Framework/CommonObjects.cs
@@ -2361,6 +2361,11 @@ namespace Org.IdentityConnectors.Framework.Common.Objects
         /// </summary>
         public static readonly String ALL_NAME = ObjectClassUtil.CreateSpecialName("ALL");
         /// <summary>
+        /// This constant defines a specific {@link #getObjectClassValue value
+        /// of ObjectClass} that is reserved for <seealso cref="ObjectClass#ANY"/>
+        /// </summary
+        public static readonly String ANY_OBJECT_NAME = ObjectClassUtil.CreateSpecialName("ANY");
+        /// <summary>
         /// Denotes an account based object.
         /// </summary>
         public static readonly ObjectClass ACCOUNT = new ObjectClass(ACCOUNT_NAME);
@@ -2379,6 +2384,11 @@ namespace Org.IdentityConnectors.Framework.Common.Objects
         /// </para>
         /// </summary>
         public static readonly ObjectClass ALL = new ObjectClass(ALL_NAME);
+        /// <summary>
+        /// Denotes any other type based object.
+        /// I.e. a device
+        /// </summary>
+        public static readonly ObjectClass ANY_OBJECT = new ObjectClass(ANY_OBJECT_NAME);
 
         private readonly String _type;
 

--- a/java/connector-framework-contract/src/main/java/org/identityconnectors/contract/test/MultiOpTests.java
+++ b/java/connector-framework-contract/src/main/java/org/identityconnectors/contract/test/MultiOpTests.java
@@ -695,14 +695,16 @@ public class MultiOpTests extends ObjectClassRunner {
     public void testGroupsPredAttribute() {
         final ObjectClassInfo accountInfo = findOInfo(ObjectClass.ACCOUNT);
         final ObjectClassInfo groupInfo = findOInfo(ObjectClass.GROUP);
+        final ObjectClassInfo anyObjectInfo = findOInfo(ObjectClass.ANY_OBJECT);
 
         // run test only in case ACCOUNT and GROUP are supported and GROUPS is supported for ACCOUNT
-        if (accountInfo != null && groupInfo != null
+        if (accountInfo != null && groupInfo != null && anyObjectInfo != null
                 && ConnectorHelper.isCRU(accountInfo, PredefinedAttributes.GROUPS_NAME)) {
 
             Uid groupUid1 = null;
             Uid groupUid2 = null;
             Uid accountUid1 = null;
+            Uid anyObjectUid1 = null;
             try {
                 // create 1st group
                 Set<Attribute> groupAttrs1 = ConnectorHelper.getCreateableAttributes(
@@ -723,6 +725,10 @@ public class MultiOpTests extends ObjectClassRunner {
 
                 accountUid1 = getConnectorFacade().create(ObjectClass.ACCOUNT, accountAttrs1, null);
 
+                Set<Attribute> anyObjectAttrs1 = ConnectorHelper.getCreateableAttributes(
+                        getDataProvider(), anyObjectInfo, getTestName(), 0, true, false);
+                anyObjectUid1 = getConnectorFacade().create(ObjectClass.ANY_OBJECT, anyObjectAttrs1, null);
+
                 // build attributes to get
                 OperationOptionsBuilder oob = new OperationOptionsBuilder();
                 oob.setAttributesToGet(ConnectorHelper.getReadableAttributesNames(accountInfo));
@@ -731,6 +737,13 @@ public class MultiOpTests extends ObjectClassRunner {
                 // get the account to make sure it exists now
                 ConnectorObject obj = getConnectorFacade().getObject(ObjectClass.ACCOUNT,
                         accountUid1, attrsToGet);
+
+                // get the any-object to make sure it exists now
+                oob = new OperationOptionsBuilder();
+                oob.setAttributesToGet(ConnectorHelper.getReadableAttributesNames(anyObjectInfo));
+                OperationOptions anyObjectAttrsToGet = oob.build();
+                ConnectorObject anyObj = getConnectorFacade().getObject(ObjectClass.ANY_OBJECT, 
+                        anyObjectUid1, anyObjectAttrsToGet);
 
                 // check that object was created properly
                 ConnectorHelper.checkObject(accountInfo, obj, accountAttrs1);
@@ -767,6 +780,8 @@ public class MultiOpTests extends ObjectClassRunner {
                         false, null);
                 ConnectorHelper.deleteObject(getConnectorFacade(), ObjectClass.ACCOUNT,
                         accountUid1, false, null);
+                ConnectorHelper.deleteObject(getConnectorFacade(), ObjectClass.ANY_OBJECT, anyObjectUid1,
+                        false, null);
             }
 
         } else {

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/ObjectClass.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/ObjectClass.java
@@ -61,6 +61,12 @@ public final class ObjectClass {
      */
     public static final String ALL_NAME = createSpecialName("ALL");
 
+    /**
+     * This constant defines a specific {@linkplain #getObjectClassValue value
+     * of ObjectClass} that is reserved for {@link ObjectClass#ANY}.
+     */
+    public static final String ANY_OBJECT_NAME = createSpecialName("ANY_OBJECT");
+
     // =======================================================================
     // Create only after all other static initializers
     // =======================================================================
@@ -99,6 +105,11 @@ public final class ObjectClass {
      * any other operation throws {@link UnsupportedOperationException}
      */
     public static final ObjectClass ALL = new ObjectClass(ALL_NAME);
+
+    /**
+     * Represents an object that is <i>neither</i> an account <i>nor</i> a group
+     */
+    public static final ObjectClass ANY_OBJECT = new ObjectClass(ANY_OBJECT_NAME);
 
     private final String type;
 

--- a/java/connector-framework/src/test/java/org/identityconnectors/framework/common/objects/ObjectClassTests.java
+++ b/java/connector-framework/src/test/java/org/identityconnectors/framework/common/objects/ObjectClassTests.java
@@ -74,9 +74,11 @@ public class ObjectClassTests {
         set.add(ObjectClass.ACCOUNT);
         set.add(ObjectClass.GROUP);
         set.add(ObjectClass.ACCOUNT);
-        assertEquals(2, set.size());
+        set.add(ObjectClass.ANY_OBJECT);
+        assertEquals(3, set.size());
         assertTrue(set.contains(ObjectClass.ACCOUNT));
         assertTrue(set.contains(ObjectClass.GROUP));
+        assertTrue(set.contains(ObjectClass.ANY_OBJECT));
 
         // Test case-insensitivity
         set = new HashSet<ObjectClass>();


### PR DESCRIPTION
Currently, there is no ObjectClass for “ANY OBJECTS”.
This capability was recently added to the LDAP bundle, although it could also be beneficial to the wider ConnID project.