### PR TITLE
Add ConnectorObjectReference#toString method (BASE-91)

### DIFF
--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/ConnectorObjectReference.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/ConnectorObjectReference.java
@@ -75,4 +75,9 @@ public class ConnectorObjectReference {
     public BaseConnectorObject getValue() {
         return Objects.requireNonNull(value);
     }
+
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName() + ": " + value;
+    }
 }


### PR DESCRIPTION
I forgot to implement that method, and the logs are ugly now.