### PR TITLE
Or filter builds ands

### DIFF
--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/filter/OrFilter.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/filter/OrFilter.java
@@ -79,7 +79,7 @@ public final class OrFilter extends CompositeFilter {
         if (subFilters.size() > 2) {
             final LinkedList<Filter> right = new LinkedList<Filter>(subFilters);
             right.removeFirst();
-            return new AndFilter(right);
+            return new OrFilter(right);
         } else if (subFilters.size() == 2) {
             return subFilters.getLast();
         } else {


### PR DESCRIPTION
It seems that using the OrFilter with a list results in nested ANDs. This showed when debuging a SQL connector. The query contained one OR and many ANDs.