### PR TITLE
[BASE-97] [BASE-98] Support for fetching partial Schema

### DIFF
--- a/java/connector-framework-contract/src/main/java/org/identityconnectors/contract/test/PartialSchemaApiOpTests.java
+++ b/java/connector-framework-contract/src/main/java/org/identityconnectors/contract/test/PartialSchemaApiOpTests.java
@@ -23,9 +23,12 @@
 
 package org.identityconnectors.contract.test;
 import org.identityconnectors.framework.api.operations.*;
+import org.identityconnectors.framework.common.objects.*;
+import org.junit.jupiter.api.Test;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 
 /**
@@ -44,4 +47,40 @@ public class PartialSchemaApiOpTests extends ContractTestBase {
         s.add(PartialSchemaApiOp.class);
         return s;
     }
+
+
+    /**
+     * Basic test case.
+     */
+    @Test
+    protected void testBasic() {
+
+        LightweightObjectClassInfo[] lightweightObjectClassInfos =  getConnectorFacade().getObjectClassInformation();
+        assertNotNull(lightweightObjectClassInfos, "Null Object class information found");
+
+        Iterator<LightweightObjectClassInfo> iterator =  Arrays.stream(lightweightObjectClassInfos).iterator();
+
+        Schema schema = null;
+        LightweightObjectClassInfo lightweightObjectClassInfo = null;
+
+        if (iterator.hasNext()){
+
+            lightweightObjectClassInfo = iterator.next();
+
+            assertNotNull(lightweightObjectClassInfo, "Null object class information produced");
+            schema = getConnectorFacade().getPartialSchema(lightweightObjectClassInfo);
+
+        }
+
+        assertNotNull(schema, "Null schema produced");
+
+        Set<ObjectClassInfo> objectClassInfos = schema.getObjectClassInfo();
+        Iterator<ObjectClassInfo> infoIterator = objectClassInfos.iterator();
+
+        assertTrue(objectClassInfos.size() ==1);
+        assertTrue(lightweightObjectClassInfo.is(infoIterator.next().getType()));
+
+
+    }
+
 }

--- a/java/connector-framework-contract/src/main/java/org/identityconnectors/contract/test/PartialSchemaApiOpTests.java
+++ b/java/connector-framework-contract/src/main/java/org/identityconnectors/contract/test/PartialSchemaApiOpTests.java
@@ -20,27 +20,28 @@
  * "Portions Copyrighted [year] [name of copyright owner]"
  * ====================
  */
-package org.identityconnectors.framework.api.operations;
 
-import org.identityconnectors.framework.common.objects.LightweightObjectClassInfo;
-import org.identityconnectors.framework.common.objects.Schema;
-import org.identityconnectors.framework.spi.Connector;
+package org.identityconnectors.contract.test;
+import org.identityconnectors.framework.api.operations.*;
+
+import java.util.HashSet;
+import java.util.Set;
+
 
 /**
- * Get the schema from the {@link Connector}.
+ * Contract test of {@link PartialSchemaApiOp} operation.
  */
-public interface PartialSchemaApiOp extends APIOperation {
+public class PartialSchemaApiOpTests extends ContractTestBase {
+
 
     /**
-     * Retrieve only a subset of the possible object classes as a schema of this {@link Connector}.
-     * The subset is defined as an array of {@link LightweightObjectClassInfo} which were provided by the
-     * {@link PartialSchemaApiOp#getObjectClassInformation()} method.
+     * {@inheritDoc}
      */
-    public Schema getPartialSchema(LightweightObjectClassInfo... ObjectClassInfo);
-
-    /**
-     * Retrieve and array of {@link LightweightObjectClassInfo} objects which can be provided in the schema of this
-     * {@link Connector}.
-     */
-    public LightweightObjectClassInfo[] getObjectClassInformation();
+    @Override
+    public Set<Class<? extends APIOperation>> getAPIOperations() {
+        Set<Class<? extends APIOperation>> s = new HashSet<>();
+        // list of required operations by this test:
+        s.add(PartialSchemaApiOp.class);
+        return s;
+    }
 }

--- a/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/AbstractConnectorFacade.java
+++ b/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/AbstractConnectorFacade.java
@@ -326,9 +326,9 @@ public abstract class AbstractConnectorFacade implements ConnectorFacade {
      * {@inheritDoc}
      */
     @Override
-    public final Schema getPartialSchema(LightweightObjectClassInfo ... ObjectClassInfo) {
+    public final Schema getPartialSchema(LightweightObjectClassInfo ... objectClassInfos) {
         return ((PartialSchemaApiOp) this.getOperationCheckSupported(PartialSchemaApiOp.class)).
-                getPartialSchema(ObjectClassInfo);
+                getPartialSchema(objectClassInfos);
     }
 
     /**

--- a/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/AbstractConnectorFacade.java
+++ b/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/AbstractConnectorFacade.java
@@ -322,6 +322,22 @@ public abstract class AbstractConnectorFacade implements ConnectorFacade {
                 discoverConfiguration();
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final Schema getPartialSchema(ObjectClass ... objectClasses) {
+        return ((PartialSchemaApiOp) this.getOperationCheckSupported(PartialSchemaApiOp.class)).getPartialSchema(objectClasses);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final ObjectClass[] getObjectClasses() {
+        return ((PartialSchemaApiOp) this.getOperationCheckSupported(PartialSchemaApiOp.class)).getObjectClasses();
+    }
+
     private static final String MSG = "Operation ''{0}'' not supported.";
 
     private APIOperation getOperationCheckSupported(final Class<? extends APIOperation> api) {

--- a/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/AbstractConnectorFacade.java
+++ b/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/AbstractConnectorFacade.java
@@ -326,16 +326,17 @@ public abstract class AbstractConnectorFacade implements ConnectorFacade {
      * {@inheritDoc}
      */
     @Override
-    public final Schema getPartialSchema(ObjectClass ... objectClasses) {
-        return ((PartialSchemaApiOp) this.getOperationCheckSupported(PartialSchemaApiOp.class)).getPartialSchema(objectClasses);
+    public final Schema getPartialSchema(LightweightObjectClassInfo ... ObjectClassInfo) {
+        return ((PartialSchemaApiOp) this.getOperationCheckSupported(PartialSchemaApiOp.class)).
+                getPartialSchema(ObjectClassInfo);
     }
 
     /**
      * {@inheritDoc}
      */
     @Override
-    public final ObjectClass[] getObjectClasses() {
-        return ((PartialSchemaApiOp) this.getOperationCheckSupported(PartialSchemaApiOp.class)).getObjectClasses();
+    public final LightweightObjectClassInfo[] getObjectClassInformation() {
+        return ((PartialSchemaApiOp) this.getOperationCheckSupported(PartialSchemaApiOp.class)).getObjectClassInformation();
     }
 
     private static final String MSG = "Operation ''{0}'' not supported.";

--- a/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/LocalConnectorFacadeImpl.java
+++ b/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/LocalConnectorFacadeImpl.java
@@ -34,6 +34,7 @@ import org.identityconnectors.framework.impl.api.AbstractConnectorFacade;
 import org.identityconnectors.framework.impl.api.LoggingProxy;
 import org.identityconnectors.framework.impl.api.local.operations.*;
 import org.identityconnectors.framework.spi.Connector;
+import org.identityconnectors.framework.spi.operations.PartialSchemaOp;
 
 /**
  * Implements all the methods of the facade.
@@ -79,6 +80,7 @@ public class LocalConnectorFacadeImpl extends AbstractConnectorFacade {
         addImplementation(SyncApiOp.class, SyncImpl.class);
         addImplementation(LiveSyncApiOp.class, LiveSyncImpl.class);
         addImplementation(DiscoverConfigurationApiOp.class, DiscoverConfigurationImpl.class);
+        addImplementation(PartialSchemaApiOp.class, PartialSchemaImpl.class);
     }
 
     // =======================================================================

--- a/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/operations/PartialSchemaImpl.java
+++ b/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/operations/PartialSchemaImpl.java
@@ -1,0 +1,89 @@
+/*
+ * ====================
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2008-2009 Sun Microsystems, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Common Development
+ * and Distribution License("CDDL") (the "License").  You may not use this file
+ * except in compliance with the License.
+ *
+ * You can obtain a copy of the License at
+ * http://opensource.org/licenses/cddl1.php
+ * See the License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * When distributing the Covered Code, include this CDDL Header Notice in each file
+ * and include the License file at http://opensource.org/licenses/cddl1.php.
+ * If applicable, add the following below this CDDL Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyrighted [year] [name of copyright owner]"
+ * ====================
+ * Portions Copyrighted 2014-2018 Evolveum
+ * Portions Copyrighted 2018 ConnId
+ */
+package org.identityconnectors.framework.impl.api.local.operations;
+
+import org.identityconnectors.common.logging.Log;
+import org.identityconnectors.framework.api.operations.PartialSchemaApiOp;
+import org.identityconnectors.framework.api.operations.SchemaApiOp;
+import org.identityconnectors.framework.common.objects.LightweightObjectClassInfo;
+import org.identityconnectors.framework.common.objects.Schema;
+import org.identityconnectors.framework.spi.Connector;
+import org.identityconnectors.framework.spi.operations.PartialSchemaOp;
+
+public class PartialSchemaImpl extends ConnectorAPIOperationRunner implements PartialSchemaApiOp {
+
+    // Special logger with SPI operation log name. Used for logging operation entry/exit
+    private static final Log OP_LOG = Log.getLog(PartialSchemaOp.class);
+
+    /**
+     * Initializes the operation works.
+     */
+    public PartialSchemaImpl(final ConnectorOperationalContext context, final Connector connector) {
+        super(context, connector);
+    }
+
+    /**
+     * Retrieve the schema from the {@link Connector}.
+     *
+     * @see SchemaApiOp#schema()
+     */
+
+
+    @Override
+    public Schema getPartialSchema(LightweightObjectClassInfo... ObjectClassInfo) {
+        SpiOperationLoggingUtil.logOpEntry(OP_LOG, getOperationalContext(), PartialSchemaOp.class, "getPartialSchema");
+
+        Schema partialSchema;
+        try {
+            partialSchema = ((PartialSchemaOp) getConnector()).getPartialSchema(ObjectClassInfo);
+        } catch (RuntimeException e) {
+            SpiOperationLoggingUtil.logOpException(OP_LOG, getOperationalContext(), PartialSchemaOp.class, "getPartialSchema", e);
+            throw e;
+        }
+
+        SpiOperationLoggingUtil.logOpExit(OP_LOG, getOperationalContext(), PartialSchemaOp.class, "getPartialSchema", partialSchema);
+
+        return partialSchema;
+    }
+
+    @Override
+    public LightweightObjectClassInfo[] getObjectClassInformation() {
+        {
+            SpiOperationLoggingUtil.logOpEntry(OP_LOG, getOperationalContext(), PartialSchemaOp.class, "getObjectClassInformation");
+
+            LightweightObjectClassInfo[] objectClassInfos;
+            try {
+                objectClassInfos = ((PartialSchemaOp) getConnector()).getObjectClassInformation();
+            } catch (RuntimeException e) {
+                SpiOperationLoggingUtil.logOpException(OP_LOG, getOperationalContext(), PartialSchemaOp.class, "getObjectClassInformation", e);
+                throw e;
+            }
+
+            SpiOperationLoggingUtil.logOpExit(OP_LOG, getOperationalContext(), PartialSchemaOp.class, "getObjectClassInformation", objectClassInfos);
+
+            return objectClassInfos;
+        }
+    }
+}

--- a/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/operations/PartialSchemaImpl.java
+++ b/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/operations/PartialSchemaImpl.java
@@ -2,7 +2,7 @@
  * ====================
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2008-2009 Sun Microsystems, Inc. All rights reserved.
+ * Copyright 2025 Evolveum. All rights reserved.
  *
  * The contents of this file are subject to the terms of the Common Development
  * and Distribution License("CDDL") (the "License").  You may not use this file
@@ -19,8 +19,6 @@
  * enclosed by brackets [] replaced by your own identifying information:
  * "Portions Copyrighted [year] [name of copyright owner]"
  * ====================
- * Portions Copyrighted 2014-2018 Evolveum
- * Portions Copyrighted 2018 ConnId
  */
 package org.identityconnectors.framework.impl.api.local.operations;
 

--- a/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/operations/PartialSchemaImpl.java
+++ b/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/operations/PartialSchemaImpl.java
@@ -50,12 +50,12 @@ public class PartialSchemaImpl extends ConnectorAPIOperationRunner implements Pa
 
 
     @Override
-    public Schema getPartialSchema(LightweightObjectClassInfo... ObjectClassInfo) {
+    public Schema getPartialSchema(LightweightObjectClassInfo... objectClassInfos) {
         SpiOperationLoggingUtil.logOpEntry(OP_LOG, getOperationalContext(), PartialSchemaOp.class, "getPartialSchema");
 
         Schema partialSchema;
         try {
-            partialSchema = ((PartialSchemaOp) getConnector()).getPartialSchema(ObjectClassInfo);
+            partialSchema = ((PartialSchemaOp) getConnector()).getPartialSchema(objectClassInfos);
         } catch (RuntimeException e) {
             SpiOperationLoggingUtil.logOpException(OP_LOG, getOperationalContext(), PartialSchemaOp.class, "getPartialSchema", e);
             throw e;

--- a/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/serializer/CommonObjectHandlers.java
+++ b/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/serializer/CommonObjectHandlers.java
@@ -369,6 +369,7 @@ class CommonObjectHandlers {
                 builder.setSubtype(decoder.readStringField("subtype", null));
                 builder.setReferencedObjectClassName(decoder.readStringField("referencedObjectClassName", null));
                 builder.setRoleInReference(decoder.readStringField("roleInReference", null));
+                builder.setDescription(decoder.readStringField("description", null));
                 return builder.build();
             }
 
@@ -384,6 +385,7 @@ class CommonObjectHandlers {
                 encoder.writeStringField("subtype", val.getSubtype());
                 encoder.writeStringField("referencedObjectClassName", val.getReferencedObjectClassName());
                 encoder.writeStringField("roleInReference", val.getRoleInReference());
+                encoder.writeStringField("description", val.getDescription());
             }
         });
 
@@ -480,11 +482,12 @@ class CommonObjectHandlers {
                 final boolean container = decoder.readBooleanField("container", false);
                 final boolean auxiliary = decoder.readBooleanField("auxiliary", false);
                 final boolean embedded = decoder.readBooleanField("embedded", false);
+                final String description = decoder.readStringField("description", null);
 
                 @SuppressWarnings("unchecked")
                 final Set<AttributeInfo> attrInfo = (Set) decoder.readObjectField("AttributeInfos", Set.class, null);
 
-                return new ObjectClassInfo(type, attrInfo, container, auxiliary, embedded);
+                return new ObjectClassInfo(type, attrInfo, container, auxiliary, embedded, description);
             }
 
             @Override
@@ -496,6 +499,7 @@ class CommonObjectHandlers {
                 encoder.writeBooleanField("auxiliary", val.isAuxiliary());
                 encoder.writeBooleanField("embedded", val.isEmbedded());
                 encoder.writeObjectField("AttributeInfos", val.getAttributeInfo(), true);
+                encoder.writeStringField("description", val.getDescription());
             }
         });
 

--- a/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/serializer/CommonObjectHandlers.java
+++ b/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/serializer/CommonObjectHandlers.java
@@ -849,5 +849,32 @@ class CommonObjectHandlers {
         });
 
         HANDLERS.add(new EnumSerializationHandler(ValueListOpenness.class, "ValueListOpenness"));
+
+        HANDLERS.add(new AbstractObjectSerializationHandler(LightweightObjectClassInfo.class,
+                "LightweightObjectClassInfo") {
+
+            @Override
+            public Object deserialize(final ObjectDecoder decoder) {
+                final String type = decoder.readStringField("type", null);
+                final boolean container = decoder.readBooleanField("container", false);
+                final boolean auxiliary = decoder.readBooleanField("auxiliary", false);
+                final boolean embedded = decoder.readBooleanField("embedded", false);
+                final String description = decoder.readStringField("description", null);
+
+                return new LightweightObjectClassInfo(type, container, auxiliary, embedded, description);
+            }
+
+            @Override
+            public void serialize(final Object object, final ObjectEncoder encoder) {
+                final LightweightObjectClassInfo val = (LightweightObjectClassInfo) object;
+
+                encoder.writeStringField("type", val.getType());
+                encoder.writeBooleanField("container", val.isContainer());
+                encoder.writeBooleanField("auxiliary", val.isAuxiliary());
+                encoder.writeBooleanField("embedded", val.isEmbedded());
+                encoder.writeStringField("description", val.getDescription());
+            }
+        });
+
     }
 }

--- a/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/serializer/OperationMappings.java
+++ b/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/serializer/OperationMappings.java
@@ -41,6 +41,7 @@ import org.identityconnectors.framework.api.operations.SyncApiOp;
 import org.identityconnectors.framework.api.operations.TestApiOp;
 import org.identityconnectors.framework.api.operations.UpdateApiOp;
 import org.identityconnectors.framework.api.operations.UpdateDeltaApiOp;
+import org.identityconnectors.framework.api.operations.PartialSchemaApiOp;
 import org.identityconnectors.framework.api.operations.ValidateApiOp;
 
 class OperationMappings {
@@ -64,5 +65,6 @@ class OperationMappings {
         MAPPINGS.add(new ObjectTypeMapperImpl(SyncApiOp.class, "SyncApiOp"));
         MAPPINGS.add(new ObjectTypeMapperImpl(LiveSyncApiOp.class, "LiveSyncApiOp"));
         MAPPINGS.add(new ObjectTypeMapperImpl(DiscoverConfigurationApiOp.class, "DiscoverConfigurationApiOp"));
+        MAPPINGS.add(new ObjectTypeMapperImpl(PartialSchemaApiOp.class, "PartialSchemaApiOp"));
     }
 }

--- a/java/connector-framework-internal/src/test/java/org/identityconnectors/framework/impl/api/ConnectorInfoManagerTestBase.java
+++ b/java/connector-framework-internal/src/test/java/org/identityconnectors/framework/impl/api/ConnectorInfoManagerTestBase.java
@@ -35,7 +35,9 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.ResourceBundle;
@@ -66,6 +68,7 @@ import org.identityconnectors.framework.common.objects.AttributeInfo;
 import org.identityconnectors.framework.common.objects.ConnectorObject;
 import org.identityconnectors.framework.common.objects.ConnectorObjectIdentification;
 import org.identityconnectors.framework.common.objects.ConnectorObjectReference;
+import org.identityconnectors.framework.common.objects.LightweightObjectClassInfo;
 import org.identityconnectors.framework.common.objects.Name;
 import org.identityconnectors.framework.common.objects.ObjectClass;
 import org.identityconnectors.framework.common.objects.ObjectClassInfo;
@@ -667,6 +670,70 @@ public abstract class ConnectorInfoManagerTestBase {
         } catch (OperationTimeoutException e) {
             //expected
         }
+    }
+
+    @Test
+    public void testGetObjectClassInformation() throws Exception {
+
+        ConnectorInfoManager manager = getConnectorInfoManager();
+        ConnectorInfo info = findConnectorInfo(manager,
+                "1.0.0.0",
+                "org.identityconnectors.testconnector.TstConnector");
+
+        ConnectorFacade facade = ConnectorFacadeFactory.getInstance()
+                .newInstance(info.createDefaultAPIConfiguration());
+        LightweightObjectClassInfo[] lightweightObjectClassInfos = facade.getObjectClassInformation();
+        assertNotNull(lightweightObjectClassInfos);
+        assertEquals(lightweightObjectClassInfos.length, 5);
+    }
+
+    @Test
+    public void testGetPartialSchema() throws Exception {
+        ConnectorInfoManager manager = getConnectorInfoManager();
+        ConnectorInfo info = findConnectorInfo(manager,
+                "1.0.0.0",
+                "org.identityconnectors.testconnector.TstConnector");
+
+        ConnectorFacade facade = ConnectorFacadeFactory.getInstance()
+                .newInstance(info.createDefaultAPIConfiguration());
+
+        LightweightObjectClassInfo[] lightweightObjectClassInfos = facade.getObjectClassInformation();
+        assertNotNull(lightweightObjectClassInfos);
+        Iterator<LightweightObjectClassInfo> iteratorLwOCI = Arrays.stream(lightweightObjectClassInfos).iterator();
+        ArrayList<LightweightObjectClassInfo> lightweightObjectClassInfoList = new ArrayList<>();
+
+        while (iteratorLwOCI.hasNext()) {
+            LightweightObjectClassInfo lightweightObjectClassInfo = iteratorLwOCI.next();
+            if (lightweightObjectClassInfo.is(TstConnector.USER_CLASS_NAME) ||
+                    lightweightObjectClassInfo.is(TstConnector.GROUP_CLASS_NAME)) {
+                lightweightObjectClassInfoList.add(lightweightObjectClassInfo);
+            }
+        }
+
+        Schema schema = facade.getPartialSchema(lightweightObjectClassInfoList.toArray(new LightweightObjectClassInfo[0]));
+
+        assertEquals(2, schema.getObjectClassInfo().size());
+
+        ObjectClassInfo userObjectClass = schema.findObjectClassInfo(TstConnector.USER_CLASS_NAME);
+        assertNotNull(userObjectClass);
+        assertNotNull(userObjectClass.getDescription());
+        assertEquals(TstConnector.USER_CLASS_DESCRIPTION, userObjectClass.getDescription());
+        userObjectClass.getAttributeInfo().stream()
+                .filter(attr -> attr.getName().equals(TstConnector.MEMBER_OF_ATTR_NAME))
+                .findFirst()
+                .ifPresentOrElse(attr -> {
+                    assertEquals(TstConnector.GROUP_CLASS_NAME, attr.getReferencedObjectClassName());
+                    assertEquals(TstConnector.GROUP_MEMBERSHIP_REFERENCE_TYPE_NAME, attr.getSubtype());
+                    assertEquals(AttributeInfo.RoleInReference.SUBJECT.toString(), attr.getRoleInReference());
+                    assertTrue(attr.isMultiValued());
+                }, () -> {
+                    fail("Attribute " + TstConnector.MEMBER_OF_ATTR_NAME + " not found");
+                });
+
+        ObjectClassInfo groupObjectClass = schema.findObjectClassInfo(TstConnector.GROUP_CLASS_NAME);
+        assertNotNull(groupObjectClass);
+        assertNotNull(groupObjectClass.getDescription());
+        assertEquals(TstConnector.GROUP_CLASS_DESCRIPTION, groupObjectClass.getDescription());
     }
 
     static File getTestBundlesDir() throws URISyntaxException {

--- a/java/connector-framework-internal/src/test/java/org/identityconnectors/framework/impl/api/ConnectorInfoManagerTestBase.java
+++ b/java/connector-framework-internal/src/test/java/org/identityconnectors/framework/impl/api/ConnectorInfoManagerTestBase.java
@@ -374,6 +374,7 @@ public abstract class ConnectorInfoManagerTestBase {
 
         ObjectClassInfo userObjectClass = schema.findObjectClassInfo(TstConnector.USER_CLASS_NAME);
         assertNotNull(userObjectClass);
+        assertNotNull(userObjectClass.getDescription());
         userObjectClass.getAttributeInfo().stream()
                 .filter(attr -> attr.getName().equals(TstConnector.MEMBER_OF_ATTR_NAME))
                 .findFirst()

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/api/ConnectorFacade.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/api/ConnectorFacade.java
@@ -33,6 +33,7 @@ import org.identityconnectors.framework.api.operations.DeleteApiOp;
 import org.identityconnectors.framework.api.operations.DiscoverConfigurationApiOp;
 import org.identityconnectors.framework.api.operations.GetApiOp;
 import org.identityconnectors.framework.api.operations.LiveSyncApiOp;
+import org.identityconnectors.framework.api.operations.PartialSchemaApiOp;
 import org.identityconnectors.framework.api.operations.ResolveUsernameApiOp;
 import org.identityconnectors.framework.api.operations.SchemaApiOp;
 import org.identityconnectors.framework.api.operations.ScriptOnConnectorApiOp;
@@ -55,7 +56,7 @@ import org.identityconnectors.framework.api.operations.ValidateApiOp;
  */
 public interface ConnectorFacade extends CreateApiOp, DeleteApiOp, SearchApiOp, UpdateApiOp, UpdateDeltaApiOp,
         SchemaApiOp, AuthenticationApiOp, ResolveUsernameApiOp, GetApiOp, ValidateApiOp, TestApiOp,
-        ScriptOnConnectorApiOp, ScriptOnResourceApiOp, SyncApiOp, LiveSyncApiOp, DiscoverConfigurationApiOp {
+        ScriptOnConnectorApiOp, ScriptOnResourceApiOp, SyncApiOp, LiveSyncApiOp, DiscoverConfigurationApiOp, PartialSchemaApiOp {
 
     /**
      * Gets the unique generated identifier of this ConnectorFacade.

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/api/operations/PartialSchemaApiOp.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/api/operations/PartialSchemaApiOp.java
@@ -1,0 +1,43 @@
+/*
+ * ====================
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2008-2009 Sun Microsystems, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Common Development
+ * and Distribution License("CDDL") (the "License").  You may not use this file
+ * except in compliance with the License.
+ *
+ * You can obtain a copy of the License at
+ * http://opensource.org/licenses/cddl1.php
+ * See the License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * When distributing the Covered Code, include this CDDL Header Notice in each file
+ * and include the License file at http://opensource.org/licenses/cddl1.php.
+ * If applicable, add the following below this CDDL Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyrighted [year] [name of copyright owner]"
+ * ====================
+ */
+package org.identityconnectors.framework.api.operations;
+
+import org.identityconnectors.framework.common.objects.ObjectClass;
+import org.identityconnectors.framework.common.objects.Schema;
+import org.identityconnectors.framework.spi.Connector;
+
+/**
+ * Get the schema from the {@link Connector}.
+ */
+public interface PartialSchemaApiOp extends APIOperation {
+
+    /**
+     * Retrieve only a subset of the possible object classes as a schema of this {@link Connector}.
+     */
+    public Schema getPartialSchema(ObjectClass ... objectClasses);
+
+    /**
+     * Retrieve and array of {@link ObjectClass} objects which can be provided in the schema of this {@link Connector}.
+     */
+    public ObjectClass[] getObjectClasses();
+}

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/api/operations/PartialSchemaApiOp.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/api/operations/PartialSchemaApiOp.java
@@ -36,7 +36,7 @@ public interface PartialSchemaApiOp extends APIOperation {
      * The subset is defined as an array of {@link LightweightObjectClassInfo} which were provided by the
      * {@link PartialSchemaApiOp#getObjectClassInformation()} method.
      */
-    public Schema getPartialSchema(LightweightObjectClassInfo... ObjectClassInfo);
+    public Schema getPartialSchema(LightweightObjectClassInfo... objectClassInfos);
 
     /**
      * Retrieve and array of {@link LightweightObjectClassInfo} objects which can be provided in the schema of this

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/api/operations/PartialSchemaApiOp.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/api/operations/PartialSchemaApiOp.java
@@ -22,7 +22,7 @@
  */
 package org.identityconnectors.framework.api.operations;
 
-import org.identityconnectors.framework.common.objects.ObjectClass;
+import org.identityconnectors.framework.common.objects.LightweightObjectClassInfo;
 import org.identityconnectors.framework.common.objects.Schema;
 import org.identityconnectors.framework.spi.Connector;
 
@@ -33,11 +33,14 @@ public interface PartialSchemaApiOp extends APIOperation {
 
     /**
      * Retrieve only a subset of the possible object classes as a schema of this {@link Connector}.
+     * The subset is defined as an array of {@link LightweightObjectClassInfo} which were provided by the
+     * {@link PartialSchemaApiOp#getObjectClassInformation()} method.
      */
-    public Schema getPartialSchema(ObjectClass ... objectClasses);
+    public Schema getPartialSchema(LightweightObjectClassInfo... ObjectClassInfo);
 
     /**
-     * Retrieve and array of {@link ObjectClass} objects which can be provided in the schema of this {@link Connector}.
+     * Retrieve and array of {@link LightweightObjectClassInfo} objects which can be provided in the schema of this
+     * {@link Connector}.
      */
-    public ObjectClass[] getObjectClasses();
+    public LightweightObjectClassInfo[] getObjectClassInformation();
 }

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/FrameworkUtil.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/FrameworkUtil.java
@@ -92,6 +92,7 @@ public final class FrameworkUtil {
         SPI_TO_API.put(SyncOp.class, SyncApiOp.class);
         SPI_TO_API.put(LiveSyncOp.class, LiveSyncApiOp.class);
         SPI_TO_API.put(DiscoverConfigurationOp.class, DiscoverConfigurationApiOp.class);
+        SPI_TO_API.put(PartialSchemaOp.class, PartialSchemaApiOp.class);
     }
 
     /**

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/AttributeInfo.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/AttributeInfo.java
@@ -65,6 +65,8 @@ public final class AttributeInfo {
 
     private final String roleInReference;
 
+    private final String description;
+
     /**
      * Enum of modifier flags to use for attributes. Note that this enum is
      * designed for configuration by exception such that an empty set of flags
@@ -177,8 +179,14 @@ public final class AttributeInfo {
     }
 
     AttributeInfo(final String name, final Class<?> type, final String subtype, final String nativeName,
+                  final Set<Flags> flags,
+                  String referencedObjectClassName, String roleInReference){
+        this(name, type, subtype, nativeName, flags, referencedObjectClassName, roleInReference, null);
+    }
+
+    AttributeInfo(final String name, final Class<?> type, final String subtype, final String nativeName,
             final Set<Flags> flags,
-            String referencedObjectClassName, String roleInReference) {
+            String referencedObjectClassName, String roleInReference, String description) {
         if (StringUtil.isBlank(name)) {
             throw new IllegalStateException("Name must not be blank!");
         }
@@ -210,6 +218,7 @@ public final class AttributeInfo {
         }
         this.referencedObjectClassName = referencedObjectClassName;
         this.roleInReference = roleInReference;
+        this.description = description;
     }
 
     /**
@@ -370,6 +379,15 @@ public final class AttributeInfo {
     }
 
     /**
+     * Returns the description of this {@link Attribute}.
+     * Can be used to determine the potential use of the {@link Attribute}.
+     * @return a string description of this {@link Attribute}
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
      * Determines if the name parameter matches this {@link AttributeInfo}.
      */
     public boolean is(String name) {
@@ -394,6 +412,9 @@ public final class AttributeInfo {
                 return false;
             }
             if (!Objects.equals(referencedObjectClassName, other.referencedObjectClassName)) {
+                return false;
+            }
+            if (!Objects.equals(description, other.getDescription())) {
                 return false;
             }
             return Objects.equals(roleInReference, other.roleInReference);

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/AttributeInfoBuilder.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/AttributeInfoBuilder.java
@@ -59,6 +59,8 @@ public final class AttributeInfoBuilder {
 
     private String roleInReference;
 
+    private String description;
+
     /**
      * Creates an builder with all the defaults set.
      *
@@ -126,7 +128,8 @@ public final class AttributeInfoBuilder {
      * @return {@link AttributeInfo} based on the properties set.
      */
     public AttributeInfo build() {
-        return new AttributeInfo(name, type, subtype, nativeName, flags, referencedObjectClassName, roleInReference);
+        return new AttributeInfo(name, type, subtype, nativeName, flags, referencedObjectClassName, roleInReference,
+                description);
     }
 
     /**
@@ -275,6 +278,11 @@ public final class AttributeInfoBuilder {
 
     public AttributeInfoBuilder setRoleInReference(String value) {
         this.roleInReference = value;
+        return this;
+    }
+
+    public AttributeInfoBuilder setDescription(String description) {
+        this.description = description;
         return this;
     }
 

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/BaseObjectClassInfoBuilder.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/BaseObjectClassInfoBuilder.java
@@ -1,0 +1,64 @@
+package org.identityconnectors.framework.common.objects;
+
+public abstract class BaseObjectClassInfoBuilder<T extends BaseObjectClassInfoBuilder,
+        O extends LightweightObjectClassInfo> {
+
+    protected boolean isContainer;
+
+    protected boolean isAuxiliary;
+
+    protected boolean isEmbedded;
+
+    protected String type;
+
+    public BaseObjectClassInfoBuilder() {
+        type = ObjectClass.ACCOUNT_NAME;
+    }
+
+    /**
+     * Sets the specified {@link ObjectClassInfo#getType() type} for the
+     * {@link ObjectClassInfo} object that is being built.
+     *
+     * (If this method is not called, the <code>ObjectClassInfo</code> that is
+     * being built will default to {@link ObjectClass#ACCOUNT_NAME} -- that is,
+     * its <code>type</code> will default to to a String value of
+     * {@link ObjectClass#ACCOUNT_NAME}.)
+     *
+     * @see ObjectClassInfo#getType()
+     * @see ObjectClass#ACCOUNT_NAME
+     */
+    public T setType(final String type) {
+        this.type = type;
+        return getThis();
+    }
+
+    /**
+     * Set to true to indicate this is a container type.
+     *
+     * @param container True if this is a container type.
+     */
+    public void setContainer(final boolean container) {
+        isContainer = container;
+    }
+
+    public void setAuxiliary(final boolean isAuxiliary) {
+        this.isAuxiliary = isAuxiliary;
+    }
+
+    public T setEmbedded(final boolean embedded) {
+
+        isEmbedded = embedded;
+        return getThis();
+    }
+
+    protected abstract T getThis();
+
+    /**
+     * Constructs an instance of an object which extends the {@link LightweightObjectClassInfo} class with any
+     * characteristics that were previously specified using this builder.
+     *
+     * @return an instance of an object which extends {@link LightweightObjectClassInfo} with the characteristics
+     * previously specified.
+     */
+    public abstract O build();
+}

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/BaseObjectClassInfoBuilder.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/BaseObjectClassInfoBuilder.java
@@ -1,3 +1,26 @@
+/*
+ * ====================
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2025 Evolveum. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Common Development
+ * and Distribution License("CDDL") (the "License").  You may not use this file
+ * except in compliance with the License.
+ *
+ * You can obtain a copy of the License at
+ * http://opensource.org/licenses/cddl1.php
+ * See the License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * When distributing the Covered Code, include this CDDL Header Notice in each file
+ * and include the License file at http://opensource.org/licenses/cddl1.php.
+ * If applicable, add the following below this CDDL Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyrighted [year] [name of copyright owner]"
+ * ====================
+ */
+
 package org.identityconnectors.framework.common.objects;
 
 public abstract class BaseObjectClassInfoBuilder<T extends BaseObjectClassInfoBuilder,

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/BaseObjectClassInfoBuilder.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/BaseObjectClassInfoBuilder.java
@@ -34,6 +34,8 @@ public abstract class BaseObjectClassInfoBuilder<T extends BaseObjectClassInfoBu
 
     protected String type;
 
+    protected String description;
+
     public BaseObjectClassInfoBuilder() {
         type = ObjectClass.ACCOUNT_NAME;
     }
@@ -71,6 +73,11 @@ public abstract class BaseObjectClassInfoBuilder<T extends BaseObjectClassInfoBu
     public T setEmbedded(final boolean embedded) {
 
         isEmbedded = embedded;
+        return getThis();
+    }
+
+    public T setDescription(final String description) {
+        this.description = description;
         return getThis();
     }
 

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/LightweightObjectClassInfo.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/LightweightObjectClassInfo.java
@@ -50,6 +50,19 @@ public class LightweightObjectClassInfo {
     /**
      * Public only for serialization; Use LightweightObjectClassInfoBuilder instead.
      *
+     * @param objectClassInfo Inheritor {@link ObjectClassInfo} class which will be simplified to
+     *                       a {@link LightweightObjectClassInfo} class
+     */
+
+    public LightweightObjectClassInfo(ObjectClassInfo objectClassInfo) {
+
+        this(objectClassInfo.getType(), objectClassInfo.isContainer(),
+                objectClassInfo.isAuxiliary(), objectClassInfo.isEmbedded(), objectClassInfo.getDescription());
+    }
+
+    /**
+     * Public only for serialization; Use LightweightObjectClassInfoBuilder instead.
+     *
      * @param type The name of the object class
      * @param isContainer True if this can contain other object classes.
      */

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/LightweightObjectClassInfo.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/LightweightObjectClassInfo.java
@@ -1,0 +1,156 @@
+package org.identityconnectors.framework.common.objects;
+
+import org.identityconnectors.common.Assertions;
+import org.identityconnectors.framework.common.serializer.SerializerUtil;
+
+import java.util.Objects;
+
+import static org.identityconnectors.framework.common.objects.NameUtil.nameHashCode;
+import static org.identityconnectors.framework.common.objects.NameUtil.namesEqual;
+
+
+/**
+ * Definition of an object class without the attributeInfos.
+ */
+public class LightweightObjectClassInfo {
+
+    private final String type;
+
+    private final boolean isContainer;
+
+    private final boolean isAuxiliary;
+
+    private final boolean isEmbedded;
+
+    private final String description;
+
+    /**
+     * Public only for serialization; Use LightweightObjectClassInfoBuilder instead.
+     *
+     * @param type The name of the object class
+     * @param isContainer True if this can contain other object classes.
+     */
+    public LightweightObjectClassInfo(
+            final String type,
+            final boolean isContainer,
+            final boolean isAuxiliary,
+            final boolean isEmbedded) {
+
+        this(type, isContainer, isAuxiliary, isEmbedded, null);
+    }
+
+    /**
+     * Public only for serialization; Use LightweightObjectClassInfoBuilder instead.
+     *
+     * @param type The name of the object class
+     * @param isContainer True if this can contain other object classes.
+     * @param description The description of the object class.
+     */
+
+    public LightweightObjectClassInfo(
+            final String type,
+            final boolean isContainer,
+            final boolean isAuxiliary,
+            final boolean isEmbedded,
+            final String description) {
+
+        Assertions.nullCheck(type, "type");
+        this.type = type;
+        this.isContainer = isContainer;
+        this.isAuxiliary = isAuxiliary;
+        this.isEmbedded = isEmbedded;
+        this.description = description;
+        // check to make sure name exists and if not throw
+    }
+
+    public boolean isContainer() {
+        return isContainer;
+    }
+
+    /**
+     * Returns flag indicating whether this is a definition of auxiliary object class.
+     * Auxiliary object classes define additional characteristics of the object.
+     */
+    public boolean isAuxiliary() {
+        return isAuxiliary;
+    }
+
+    /**
+     * If {@code true}, objects of this class are meant to be embedded in other objects.
+     * (They may or may not be queryable or updatable directly.)
+     *
+     * Currently, this information serves just as a hint for the client code. In the future,
+     * we may relax some of requirements on embedded objects, for example, they may not need to have
+     * the {@link Name} and/or {@link Uid} attributes.
+     */
+    public boolean isEmbedded() {
+        return isEmbedded;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * Returns the description of this object class.
+     * Can be used to determine the potential use of the object class.
+     * @return a string description of this object class
+     */
+    public String getDescription() {
+        return description;
+    }
+    /**
+     * Determines if the 'name' matches this {@link LightweightObjectClassInfo}.
+     *
+     * @param name case-insensitive string representation of the LightweightObjectClassInfo's type.
+     * @return <code>true</code> if the case insensitive type is equal to that of the one in this
+     * {@link LightweightObjectClassInfo}.
+     */
+    public boolean is(final String name) {
+        return namesEqual(type, name);
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        // test identity
+        if (this == obj) {
+            return true;
+        }
+        // test for null..
+        if (obj == null) {
+            return false;
+        }
+        // test that the exact class matches
+        if (!(getClass().equals(obj.getClass()))) {
+            return false;
+        }
+
+        LightweightObjectClassInfo other = (LightweightObjectClassInfo) obj;
+
+        if (!is(other.getType())) {
+            return false;
+        }
+        if (!isContainer == other.isContainer) {
+            return false;
+        }
+        if (!isAuxiliary == other.isAuxiliary) {
+            return false;
+        }
+
+        if (!Objects.equals(description, other.getDescription())) {
+            return false;
+        }
+
+        return !isEmbedded != other.isEmbedded;
+    }
+
+    @Override
+    public int hashCode() {
+        return nameHashCode(type);
+    }
+
+    @Override
+    public String toString() {
+        return SerializerUtil.serializeXmlObject(this, false);
+    }
+}

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/LightweightObjectClassInfo.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/LightweightObjectClassInfo.java
@@ -1,3 +1,26 @@
+/*
+ * ====================
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2025 Evolveum. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Common Development
+ * and Distribution License("CDDL") (the "License").  You may not use this file
+ * except in compliance with the License.
+ *
+ * You can obtain a copy of the License at
+ * http://opensource.org/licenses/cddl1.php
+ * See the License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * When distributing the Covered Code, include this CDDL Header Notice in each file
+ * and include the License file at http://opensource.org/licenses/cddl1.php.
+ * If applicable, add the following below this CDDL Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyrighted [year] [name of copyright owner]"
+ * ====================
+ */
+
 package org.identityconnectors.framework.common.objects;
 
 import org.identityconnectors.common.Assertions;

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/LightweightObjectClassInfoBuilder.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/LightweightObjectClassInfoBuilder.java
@@ -1,0 +1,25 @@
+package org.identityconnectors.framework.common.objects;
+
+public class LightweightObjectClassInfoBuilder extends BaseObjectClassInfoBuilder<LightweightObjectClassInfoBuilder,
+        LightweightObjectClassInfo> {
+    @Override
+    protected LightweightObjectClassInfoBuilder getThis() {
+        return this;
+    }
+
+    /**
+     * Constructs an instance of {@link LightweightObjectClassInfo} with any
+     * characteristics that were previously specified using this builder.
+     *
+     * @return an instance of {@link LightweightObjectClassInfo} with the characteristics
+     * previously specified.
+     */
+    @Override
+    public LightweightObjectClassInfo build() {
+        return new LightweightObjectClassInfo(
+                type,
+                isContainer,
+                isAuxiliary,
+                isEmbedded);
+    }
+}

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/LightweightObjectClassInfoBuilder.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/LightweightObjectClassInfoBuilder.java
@@ -43,6 +43,7 @@ public class LightweightObjectClassInfoBuilder extends BaseObjectClassInfoBuilde
                 type,
                 isContainer,
                 isAuxiliary,
-                isEmbedded);
+                isEmbedded,
+                description);
     }
 }

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/LightweightObjectClassInfoBuilder.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/LightweightObjectClassInfoBuilder.java
@@ -1,3 +1,26 @@
+/*
+ * ====================
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2025 Evolveum. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Common Development
+ * and Distribution License("CDDL") (the "License").  You may not use this file
+ * except in compliance with the License.
+ *
+ * You can obtain a copy of the License at
+ * http://opensource.org/licenses/cddl1.php
+ * See the License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * When distributing the Covered Code, include this CDDL Header Notice in each file
+ * and include the License file at http://opensource.org/licenses/cddl1.php.
+ * If applicable, add the following below this CDDL Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyrighted [year] [name of copyright owner]"
+ * ====================
+ */
+
 package org.identityconnectors.framework.common.objects;
 
 public class LightweightObjectClassInfoBuilder extends BaseObjectClassInfoBuilder<LightweightObjectClassInfoBuilder,

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/ObjectClassInfo.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/ObjectClassInfo.java
@@ -24,7 +24,6 @@
 package org.identityconnectors.framework.common.objects;
 
 import static org.identityconnectors.framework.common.objects.NameUtil.nameHashCode;
-import static org.identityconnectors.framework.common.objects.NameUtil.namesEqual;
 
 import java.util.Map;
 import java.util.Objects;
@@ -39,19 +38,9 @@ import org.identityconnectors.framework.common.serializer.SerializerUtil;
  * @author Will Droste
  * @since 1.0
  */
-public final class ObjectClassInfo {
-
-    private final String type;
+public final class ObjectClassInfo extends LightweightObjectClassInfo {
 
     private final Set<AttributeInfo> attributeInfos;
-
-    private final boolean isContainer;
-
-    private final boolean isAuxiliary;
-
-    private final boolean isEmbedded;
-
-    private final String description;
 
     /**
      * Public only for serialization; Use ObjectClassInfoBuilder instead.
@@ -87,13 +76,9 @@ public final class ObjectClassInfo {
             final boolean isEmbedded,
             final String description) {
 
-        Assertions.nullCheck(type, "type");
-        this.type = type;
+        super(type, isContainer, isAuxiliary, isEmbedded, description);
+
         this.attributeInfos = CollectionUtil.newReadOnlySet(attrInfo);
-        this.isContainer = isContainer;
-        this.isAuxiliary = isAuxiliary;
-        this.isEmbedded = isEmbedded;
-        this.description = description;
         // check to make sure name exists and if not throw
         Map<String, AttributeInfo> map = AttributeInfoUtil.toMap(attrInfo);
         if (!map.containsKey(Name.NAME)) {
@@ -101,55 +86,9 @@ public final class ObjectClassInfo {
         }
     }
 
-    public boolean isContainer() {
-        return isContainer;
-    }
-
-    /**
-     * Returns flag indicating whether this is a definition of auxiliary object class.
-     * Auxiliary object classes define additional characteristics of the object.
-     */
-    public boolean isAuxiliary() {
-        return isAuxiliary;
-    }
-
-    /**
-     * If {@code true}, objects of this class are meant to be embedded in other objects.
-     * (They may or may not be queryable or updatable directly.)
-     *
-     * Currently, this information serves just as a hint for the client code. In the future,
-     * we may relax some of requirements on embedded objects, for example, they may not need to have
-     * the {@link Name} and/or {@link Uid} attributes.
-     */
-    public boolean isEmbedded() {
-        return isEmbedded;
-    }
 
     public Set<AttributeInfo> getAttributeInfo() {
         return CollectionUtil.newReadOnlySet(attributeInfos);
-    }
-
-    public String getType() {
-        return type;
-    }
-
-    /**
-     * Returns the description of this object class.
-     * Can be used to determine the potential use of the object class.
-     * @return a string description of this object class
-     */
-    public String getDescription() {
-        return description;
-    }
-    /**
-     * Determines if the 'name' matches this {@link ObjectClassInfo}.
-     *
-     * @param name case-insensitive string representation of the ObjectClassInfo's type.
-     * @return <code>true</code> if the case insensitive type is equal to that of the one in this
-     * {@link ObjectClassInfo}.
-     */
-    public boolean is(final String name) {
-        return namesEqual(type, name);
     }
 
     @Override
@@ -175,23 +114,23 @@ public final class ObjectClassInfo {
         if (!CollectionUtil.equals(getAttributeInfo(), other.getAttributeInfo())) {
             return false;
         }
-        if (!isContainer == other.isContainer) {
+        if (!isContainer() == other.isContainer()) {
             return false;
         }
-        if (!isAuxiliary == other.isAuxiliary) {
-            return false;
-        }
-
-        if (!Objects.equals(description, other.getDescription())) {
+        if (!isAuxiliary() == other.isAuxiliary()) {
             return false;
         }
 
-        return !isEmbedded != other.isEmbedded;
+        if (!Objects.equals(getDescription(), other.getDescription())) {
+            return false;
+        }
+
+        return !isEmbedded() != other.isEmbedded();
     }
 
     @Override
     public int hashCode() {
-        return nameHashCode(type);
+        return nameHashCode(getType());
     }
 
     @Override

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/ObjectClassInfo.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/ObjectClassInfo.java
@@ -59,8 +59,26 @@ public final class ObjectClassInfo {
      * @param type The name of the object class
      * @param attrInfo The attributes of the object class.
      * @param isContainer True if this can contain other object classes.
+     */
+    public ObjectClassInfo(
+            final String type,
+            final Set<AttributeInfo> attrInfo,
+            final boolean isContainer,
+            final boolean isAuxiliary,
+            final boolean isEmbedded) {
+
+        this(type, attrInfo, isContainer, isAuxiliary, isEmbedded, null);
+    }
+
+    /**
+     * Public only for serialization; Use ObjectClassInfoBuilder instead.
+     *
+     * @param type The name of the object class
+     * @param attrInfo The attributes of the object class.
+     * @param isContainer True if this can contain other object classes.
      * @param description The description of the object class.
      */
+
     public ObjectClassInfo(
             final String type,
             final Set<AttributeInfo> attrInfo,
@@ -75,12 +93,12 @@ public final class ObjectClassInfo {
         this.isContainer = isContainer;
         this.isAuxiliary = isAuxiliary;
         this.isEmbedded = isEmbedded;
+        this.description = description;
         // check to make sure name exists and if not throw
         Map<String, AttributeInfo> map = AttributeInfoUtil.toMap(attrInfo);
         if (!map.containsKey(Name.NAME)) {
             throw new IllegalArgumentException("Missing 'Name' attribute info.");
         }
-        this.description = description;
     }
 
     public boolean isContainer() {
@@ -116,9 +134,9 @@ public final class ObjectClassInfo {
     }
 
     /**
-     * Returns the description of this {@link ObjectClass}.
-     * Can be used to determine the potential use of the {@link ObjectClass}.
-     * @return a string description of this {@link ObjectClass}
+     * Returns the description of this object class.
+     * Can be used to determine the potential use of the object class.
+     * @return a string description of this object class
      */
     public String getDescription() {
         return description;
@@ -163,9 +181,11 @@ public final class ObjectClassInfo {
         if (!isAuxiliary == other.isAuxiliary) {
             return false;
         }
+
         if (!Objects.equals(description, other.getDescription())) {
             return false;
         }
+
         return !isEmbedded != other.isEmbedded;
     }
 

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/ObjectClassInfo.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/ObjectClassInfo.java
@@ -27,6 +27,7 @@ import static org.identityconnectors.framework.common.objects.NameUtil.nameHashC
 import static org.identityconnectors.framework.common.objects.NameUtil.namesEqual;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import org.identityconnectors.common.Assertions;
 import org.identityconnectors.common.CollectionUtil;
@@ -50,19 +51,23 @@ public final class ObjectClassInfo {
 
     private final boolean isEmbedded;
 
+    private final String description;
+
     /**
      * Public only for serialization; Use ObjectClassInfoBuilder instead.
      *
      * @param type The name of the object class
      * @param attrInfo The attributes of the object class.
      * @param isContainer True if this can contain other object classes.
+     * @param description The description of the object class.
      */
     public ObjectClassInfo(
             final String type,
             final Set<AttributeInfo> attrInfo,
             final boolean isContainer,
             final boolean isAuxiliary,
-            final boolean isEmbedded) {
+            final boolean isEmbedded,
+            final String description) {
 
         Assertions.nullCheck(type, "type");
         this.type = type;
@@ -75,6 +80,7 @@ public final class ObjectClassInfo {
         if (!map.containsKey(Name.NAME)) {
             throw new IllegalArgumentException("Missing 'Name' attribute info.");
         }
+        this.description = description;
     }
 
     public boolean isContainer() {
@@ -109,6 +115,14 @@ public final class ObjectClassInfo {
         return type;
     }
 
+    /**
+     * Returns the description of this {@link ObjectClass}.
+     * Can be used to determine the potential use of the {@link ObjectClass}.
+     * @return a string description of this {@link ObjectClass}
+     */
+    public String getDescription() {
+        return description;
+    }
     /**
      * Determines if the 'name' matches this {@link ObjectClassInfo}.
      *
@@ -147,6 +161,9 @@ public final class ObjectClassInfo {
             return false;
         }
         if (!isAuxiliary == other.isAuxiliary) {
+            return false;
+        }
+        if (!Objects.equals(description, other.getDescription())) {
             return false;
         }
         return !isEmbedded != other.isEmbedded;

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/ObjectClassInfoBuilder.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/ObjectClassInfoBuilder.java
@@ -93,4 +93,35 @@ public final class ObjectClassInfoBuilder extends BaseObjectClassInfoBuilder<Obj
                 isEmbedded,
                 description);
     }
+
+
+    // Binary level backwards compatibility
+    // Moving method to superclass is source-level backwards compatible change, but not binary-level backwards compatible
+    // change, so we need to override this methods in order to provide backwards compatibility for connectors builded
+    // with previous version of APIs.
+
+    @Override
+    public ObjectClassInfoBuilder setDescription(String description) {
+        return super.setDescription(description);
+    }
+
+    @Override
+    public ObjectClassInfoBuilder setEmbedded(boolean embedded) {
+        return super.setEmbedded(embedded);
+    }
+
+    @Override
+    public ObjectClassInfoBuilder setType(String type) {
+        return super.setType(type);
+    }
+
+    @Override
+    public void setAuxiliary(boolean isAuxiliary) {
+        super.setAuxiliary(isAuxiliary);
+    }
+
+    @Override
+    public void setContainer(boolean container) {
+        super.setContainer(container);
+    }
 }

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/ObjectClassInfoBuilder.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/ObjectClassInfoBuilder.java
@@ -90,6 +90,7 @@ public final class ObjectClassInfoBuilder extends BaseObjectClassInfoBuilder<Obj
                 CollectionUtil.newSet(attributeInfoMap.values()),
                 isContainer,
                 isAuxiliary,
-                isEmbedded);
+                isEmbedded,
+                description);
     }
 }

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/ObjectClassInfoBuilder.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/ObjectClassInfoBuilder.java
@@ -31,39 +31,16 @@ import org.identityconnectors.common.CollectionUtil;
 /**
  * Simplifies the construction of {@link ObjectClassInfo} instances.
  */
-public final class ObjectClassInfoBuilder {
-
-    private boolean isContainer;
-
-    private boolean isAuxiliary;
-
-    private boolean isEmbedded;
-
-    private String type;
+public final class ObjectClassInfoBuilder extends BaseObjectClassInfoBuilder<ObjectClassInfoBuilder,
+        ObjectClassInfo> {
 
     private final Map<String, AttributeInfo> attributeInfoMap;
 
     public ObjectClassInfoBuilder() {
-        type = ObjectClass.ACCOUNT_NAME;
+        super();
         attributeInfoMap = new HashMap<>();
     }
 
-    /**
-     * Sets the specified {@link ObjectClassInfo#getType() type} for the
-     * {@link ObjectClassInfo} object that is being built.
-     *
-     * (If this method is not called, the <code>ObjectClassInfo</code> that is
-     * being built will default to {@link ObjectClass#ACCOUNT_NAME} -- that is,
-     * its <code>type</code> will default to to a String value of
-     * {@link ObjectClass#ACCOUNT_NAME}.)
-     *
-     * @see ObjectClassInfo#getType()
-     * @see ObjectClass#ACCOUNT_NAME
-     */
-    public ObjectClassInfoBuilder setType(final String type) {
-        this.type = type;
-        return this;
-    }
 
     private static final String FORMAT = "AttributeInfo of name '%s' already exists!";
 
@@ -90,21 +67,8 @@ public final class ObjectClassInfoBuilder {
         return this;
     }
 
-    /**
-     * Set to true to indicate this is a container type.
-     *
-     * @param container True if this is a container type.
-     */
-    public void setContainer(final boolean container) {
-        isContainer = container;
-    }
-
-    public void setAuxiliary(final boolean isAuxiliary) {
-        this.isAuxiliary = isAuxiliary;
-    }
-
-    public ObjectClassInfoBuilder setEmbedded(final boolean embedded) {
-        isEmbedded = embedded;
+    @Override
+    protected ObjectClassInfoBuilder getThis() {
         return this;
     }
 
@@ -115,6 +79,7 @@ public final class ObjectClassInfoBuilder {
      * @return an instance of {@link ObjectClassInfo} with the characteristics
      * previously specified.
      */
+    @Override
     public ObjectClassInfo build() {
         // determine if name is missing and add it by default
         if (!attributeInfoMap.containsKey(Name.NAME)) {

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/SchemaBuilder.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/common/objects/SchemaBuilder.java
@@ -44,11 +44,7 @@ import org.identityconnectors.framework.api.operations.UpdateApiOp;
 import org.identityconnectors.framework.api.operations.UpdateDeltaApiOp;
 import org.identityconnectors.framework.common.FrameworkUtil;
 import org.identityconnectors.framework.spi.Connector;
-import org.identityconnectors.framework.spi.operations.SPIOperation;
-import org.identityconnectors.framework.spi.operations.SchemaOp;
-import org.identityconnectors.framework.spi.operations.ScriptOnConnectorOp;
-import org.identityconnectors.framework.spi.operations.ScriptOnResourceOp;
-import org.identityconnectors.framework.spi.operations.TestOp;
+import org.identityconnectors.framework.spi.operations.*;
 
 /**
  * Simple builder class to help facilitate creating a {@link Schema} object.
@@ -147,7 +143,8 @@ public final class SchemaBuilder {
             declaredObjectClasses.add(objectClassInfo);
             for (Class<? extends SPIOperation> spi : operations) {
                 if (SchemaOp.class.equals(spi) || ScriptOnConnectorOp.class.equals(spi)
-                        || ScriptOnResourceOp.class.equals(spi) || TestOp.class.equals(spi)) {
+                        || ScriptOnResourceOp.class.equals(spi) || TestOp.class.equals(spi)
+                        || PartialSchemaOp.class.equals(spi)) {
                     continue;
                 }
                 Set<Class<? extends APIOperation>> apiOperations = FrameworkUtil.spi2apis(spi);
@@ -217,7 +214,7 @@ public final class SchemaBuilder {
             }
             declaredOperationOptions.add(operationOptionInfo);
             for (Class<? extends SPIOperation> spi : operations) {
-                if (SchemaOp.class.equals(spi) || TestOp.class.equals(spi)) {
+                if (SchemaOp.class.equals(spi) || TestOp.class.equals(spi) || PartialSchemaOp.class.equals(spi)) {
                     continue;
                 }
                 Set<Class<? extends APIOperation>> apiOperations = FrameworkUtil.spi2apis(spi);

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/spi/operations/PartialSchemaOp.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/spi/operations/PartialSchemaOp.java
@@ -1,0 +1,67 @@
+/*
+ * ====================
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2008-2009 Sun Microsystems, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Common Development
+ * and Distribution License("CDDL") (the "License").  You may not use this file
+ * except in compliance with the License.
+ *
+ * You can obtain a copy of the License at
+ * http://opensource.org/licenses/cddl1.php
+ * See the License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * When distributing the Covered Code, include this CDDL Header Notice in each file
+ * and include the License file at http://opensource.org/licenses/cddl1.php.
+ * If applicable, add the following below this CDDL Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyrighted [year] [name of copyright owner]"
+ * ====================
+ */
+package org.identityconnectors.framework.spi.operations;
+
+import org.identityconnectors.framework.common.objects.ObjectClass;
+import org.identityconnectors.framework.common.objects.Schema;
+import org.identityconnectors.framework.spi.Connector;
+
+/**
+ * Implement this interface to allow the Connector to return an array of connector
+ * Object Classes (representing the types of object on the target resource)
+ * which the connector is capable of managing.
+ * Based on this the client is capable of choosing for which type of
+ * objects should the connector provide more information (which operations
+ * and which options the Connector supports for each type of object).
+ */
+public interface PartialSchemaOp extends SPIOperation {
+
+    /**
+     * Describes a subset of the types of objects this {@link Connector} supports.
+     *
+     * This method is considered an operation since determining supported
+     * objects may require configuration information and allows this
+     * determination to be dynamic.
+     * <p>
+     * The special {@link org.identityconnectors.framework.common.objects.Uid}
+     * attribute should never appear in the schema, as it is not a true
+     * attribute of an object, rather a reference to it. If your resource
+     * object-class has a writable unique id attribute that is different than
+     * its {@link org.identityconnectors.framework.common.objects.Name}, then
+     * your schema should contain a resource-specific attribute that represents
+     * this unique id. For example, a Unix account object might contain
+     * <I>unix_uid</I>.
+     *
+     * @return a subset of the basic schema supported by this {@link Connector}.
+     */
+    Schema getPartialSchema(ObjectClass... objectClasses);
+
+    /**
+     * Provides the client with an array of {@link ObjectClass} which this {@link Connector} supports.
+     * The list can be used in the {@link org.identityconnectors.framework.api.operations.PartialSchemaApiOp} method
+     * to request subset of the {@link ObjectClass} objects which this {@link Connector} is capable of managing.
+     *
+     * @return an array of the Object Classes supported by this {@link Connector}.
+     */
+    public ObjectClass[] getObjectClasses();
+}

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/spi/operations/PartialSchemaOp.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/spi/operations/PartialSchemaOp.java
@@ -53,7 +53,7 @@ public interface PartialSchemaOp extends SPIOperation {
      *
      * @return a subset of the basic schema supported by this {@link Connector}.
      */
-    Schema getPartialSchema(LightweightObjectClassInfo... ObjectClassInfo);
+    Schema getPartialSchema(LightweightObjectClassInfo... objectClassInfos);
 
     /**
      * Provides the client with an array of {@link LightweightObjectClassInfo} which this {@link Connector} supports.

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/spi/operations/PartialSchemaOp.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/spi/operations/PartialSchemaOp.java
@@ -2,7 +2,7 @@
  * ====================
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright 2008-2009 Sun Microsystems, Inc. All rights reserved.
+ * Copyright 2025 Evolveum. All rights reserved.
  *
  * The contents of this file are subject to the terms of the Common Development
  * and Distribution License("CDDL") (the "License").  You may not use this file

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/spi/operations/PartialSchemaOp.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/spi/operations/PartialSchemaOp.java
@@ -22,7 +22,7 @@
  */
 package org.identityconnectors.framework.spi.operations;
 
-import org.identityconnectors.framework.common.objects.ObjectClass;
+import org.identityconnectors.framework.common.objects.LightweightObjectClassInfo;
 import org.identityconnectors.framework.common.objects.Schema;
 import org.identityconnectors.framework.spi.Connector;
 
@@ -38,7 +38,6 @@ public interface PartialSchemaOp extends SPIOperation {
 
     /**
      * Describes a subset of the types of objects this {@link Connector} supports.
-     *
      * This method is considered an operation since determining supported
      * objects may require configuration information and allows this
      * determination to be dynamic.
@@ -54,14 +53,14 @@ public interface PartialSchemaOp extends SPIOperation {
      *
      * @return a subset of the basic schema supported by this {@link Connector}.
      */
-    Schema getPartialSchema(ObjectClass... objectClasses);
+    Schema getPartialSchema(LightweightObjectClassInfo... ObjectClassInfo);
 
     /**
-     * Provides the client with an array of {@link ObjectClass} which this {@link Connector} supports.
+     * Provides the client with an array of {@link LightweightObjectClassInfo} which this {@link Connector} supports.
      * The list can be used in the {@link org.identityconnectors.framework.api.operations.PartialSchemaApiOp} method
-     * to request subset of the {@link ObjectClass} objects which this {@link Connector} is capable of managing.
+     * to request a schema of a subset of the objects which this {@link Connector} is capable of managing.
      *
-     * @return an array of the Object Classes supported by this {@link Connector}.
+     * @return an array of the partial Object Class information supported by this {@link Connector}.
      */
-    public ObjectClass[] getObjectClasses();
+    public LightweightObjectClassInfo[] getObjectClassInformation();
 }

--- a/java/testbundlev1/src/main/java/org/identityconnectors/testconnector/TstConnector.java
+++ b/java/testbundlev1/src/main/java/org/identityconnectors/testconnector/TstConnector.java
@@ -103,12 +103,12 @@ public class TstConnector implements CreateOp, PoolableConnector, SchemaOp, Sear
 
     public static final String GROUP_2_NAME = "group2";
 
-    private static final String USER_CLASS_DESCRIPTION = "A User object is a digital identity object that represents a single human user or, a non-human agent (e.g., service account) authorized to access digital resources.";
+    public static final String USER_CLASS_DESCRIPTION = "A User object is a digital identity object that represents a single human user or, a non-human agent (e.g., service account) authorized to access digital resources.";
     private static final String USER_CLASS_UID_DESCRIPTION = "A unique, immutable identifier for the user.";
     private static final String USER_CLASS_NAME_DESCRIPTION = "A human-readable login name.";
     private static final String USER_CLASS_MEMBER_OF_DESCRIPTION = "Unique identifiers of groups represented as a list of memberships for policy inheritance.";
     private static final String USER_CLASS_ACCESS_DESCRIPTION = "Unique identifiers of group access policies, .";
-    private static final String GROUP_CLASS_DESCRIPTION = "A Group is a logical container object that represents a collection of user accounts or other groups.";
+    public static final String GROUP_CLASS_DESCRIPTION = "A Group is a logical container object that represents a collection of user accounts or other groups.";
     private static final String GROUP_CLASS_UID_DESCRIPTION = "A unique, immutable identifier for the group.";
     private static final String GROUP_CLASS_NAME_DESCRIPTION = "A human-readable name.";
     private static final String GROUP_CLASS_MEMBERS_ATTR_DESCRIPTION = "List of user identifiers or nested group identifiers.";
@@ -396,6 +396,7 @@ public class TstConnector implements CreateOp, PoolableConnector, SchemaOp, Sear
             objectClassInfoBuilder.setAuxiliary(lightweightObjectClassInfo.isAuxiliary());
             objectClassInfoBuilder.setContainer(lightweightObjectClassInfo.isContainer());
             objectClassInfoBuilder.addAllAttributeInfo(buildAttributeInfos(type));
+            schemaBuilder.defineObjectClass(objectClassInfoBuilder.build());
         }
 
         return schemaBuilder.build();

--- a/java/testbundlev1/src/main/java/org/identityconnectors/testconnector/TstConnector.java
+++ b/java/testbundlev1/src/main/java/org/identityconnectors/testconnector/TstConnector.java
@@ -58,6 +58,7 @@ import org.identityconnectors.framework.spi.SearchResultsHandler;
 import org.identityconnectors.framework.spi.SyncTokenResultsHandler;
 import org.identityconnectors.framework.spi.operations.CreateOp;
 import org.identityconnectors.framework.spi.operations.LiveSyncOp;
+import org.identityconnectors.framework.spi.operations.PartialSchemaOp;
 import org.identityconnectors.framework.spi.operations.SchemaOp;
 import org.identityconnectors.framework.spi.operations.SearchOp;
 import org.identityconnectors.framework.spi.operations.SyncOp;
@@ -67,7 +68,7 @@ import org.identityconnectors.testcommon.TstCommon;
         displayNameKey = "TestConnector",
         categoryKey = "TestConnector.category",
         configurationClass = TstConnectorConfig.class)
-public class TstConnector implements CreateOp, PoolableConnector, SchemaOp, SearchOp<String>, SyncOp, LiveSyncOp {
+public class TstConnector implements CreateOp, PoolableConnector, SchemaOp, SearchOp<String>, SyncOp, LiveSyncOp, PartialSchemaOp {
 
     public static final String USER_CLASS_NAME = "user";
 
@@ -101,6 +102,18 @@ public class TstConnector implements CreateOp, PoolableConnector, SchemaOp, Sear
     public static final String GROUP_1_NAME = "group1";
 
     public static final String GROUP_2_NAME = "group2";
+
+    private static final String USER_CLASS_DESCRIPTION = "A User object is a digital identity object that represents a single human user or, a non-human agent (e.g., service account) authorized to access digital resources.";
+    private static final String USER_CLASS_UID_DESCRIPTION = "A unique, immutable identifier for the user.";
+    private static final String USER_CLASS_NAME_DESCRIPTION = "A human-readable login name.";
+    private static final String USER_CLASS_MEMBER_OF_DESCRIPTION = "Unique identifiers of groups represented as a list of memberships for policy inheritance.";
+    private static final String USER_CLASS_ACCESS_DESCRIPTION = "Unique identifiers of group access policies, .";
+    private static final String GROUP_CLASS_DESCRIPTION = "A Group is a logical container object that represents a collection of user accounts or other groups.";
+    private static final String GROUP_CLASS_UID_DESCRIPTION = "A unique, immutable identifier for the group.";
+    private static final String GROUP_CLASS_NAME_DESCRIPTION = "A human-readable name.";
+    private static final String GROUP_CLASS_MEMBERS_ATTR_DESCRIPTION = "List of user identifiers or nested group identifiers.";
+    private static final String ACCESS_CLASS_DESCRIPTION = "This object represents a form of access to a group, either by another group or a user.";
+    private static final String ACCESS_CLASS_ATTR_REFERENCE_DESCRIPTION = "Reference attribute representing the relationship between a group and a user";
 
     private static int _connectionCount = 0;
 
@@ -327,57 +340,24 @@ public class TstConnector implements CreateOp, PoolableConnector, SchemaOp, Sear
         SchemaBuilder schemaBuilder = new SchemaBuilder(TstConnector.class);
         for (int i = 0; i < 2; i++) {
             ObjectClassInfoBuilder classBuilder = new ObjectClassInfoBuilder();
-            classBuilder.setType("class" + i);
-            for (int j = 0; j < 200; j++) {
-                classBuilder.addAttributeInfo(AttributeInfoBuilder.build("attributename" + j, String.class));
-            }
+            String type = "class" + i;
+            classBuilder.setType(type);
+            classBuilder.addAllAttributeInfo(buildAttributeInfos(type));
             schemaBuilder.defineObjectClass(classBuilder.build());
         }
         // Special classes to test object references
         schemaBuilder.defineObjectClass(
                 new ObjectClassInfoBuilder()
                         .setType(USER_CLASS_NAME)
-                        .addAttributeInfo(
-                                new AttributeInfoBuilder(Uid.NAME, String.class)
-                                        .setRequired(true)
-                                        .build())
-                        .addAttributeInfo(
-                                new AttributeInfoBuilder(Name.NAME, String.class)
-                                        .setRequired(true)
-                                        .build())
-                        .addAttributeInfo(
-                                new AttributeInfoBuilder(MEMBER_OF_ATTR_NAME, ConnectorObjectReference.class)
-                                        .setReferencedObjectClassName(GROUP_CLASS_NAME)
-                                        .setSubtype(GROUP_MEMBERSHIP_REFERENCE_TYPE_NAME)
-                                        .setRoleInReference(RoleInReference.SUBJECT.toString())
-                                        .setMultiValued(true)
-                                        .build())
-                        .addAttributeInfo(
-                                new AttributeInfoBuilder(ACCESS_ATTR_NAME, ConnectorObjectReference.class)
-                                        .setReferencedObjectClassName(ACCESS_CLASS_NAME)
-                                        .setRoleInReference(RoleInReference.SUBJECT.toString())
-                                        .setMultiValued(true)
-                                        .build())
+                        .setDescription(USER_CLASS_DESCRIPTION)
+                        .addAllAttributeInfo(buildAttributeInfos(USER_CLASS_NAME))
                         .build());
 
         schemaBuilder.defineObjectClass(
                 new ObjectClassInfoBuilder()
                         .setType(GROUP_CLASS_NAME)
-                        .addAttributeInfo(
-                                new AttributeInfoBuilder(Uid.NAME, String.class)
-                                        .setRequired(true)
-                                        .build())
-                        .addAttributeInfo(
-                                new AttributeInfoBuilder(Name.NAME, String.class)
-                                        .setRequired(true)
-                                        .build())
-                        .addAttributeInfo(
-                                new AttributeInfoBuilder(MEMBERS_ATTR_NAME, ConnectorObjectReference.class)
-                                        .setReferencedObjectClassName(USER_CLASS_NAME)
-                                        .setSubtype(GROUP_MEMBERSHIP_REFERENCE_TYPE_NAME)
-                                        .setRoleInReference(RoleInReference.OBJECT.toString())
-                                        .setMultiValued(true)
-                                        .build())
+                        .setDescription(GROUP_CLASS_DESCRIPTION)
+                        .addAllAttributeInfo(buildAttributeInfos(GROUP_CLASS_NAME))
                         .build());
 
         // A bit artificial class to test object references: defines which user
@@ -386,10 +366,8 @@ public class TstConnector implements CreateOp, PoolableConnector, SchemaOp, Sear
                 new ObjectClassInfoBuilder()
                         .setType(ACCESS_CLASS_NAME)
                         .setEmbedded(true)
-                        .addAttributeInfo(
-                                new AttributeInfoBuilder(GROUP_ATTR_NAME, ConnectorObjectReference.class)
-                                        .setReferencedObjectClassName(GROUP_CLASS_NAME)
-                                        .build())
+                        .setDescription(ACCESS_CLASS_DESCRIPTION)
+                        .addAllAttributeInfo(buildAttributeInfos(ACCESS_CLASS_NAME))
                         .build());
 
         return schemaBuilder.build();
@@ -397,5 +375,131 @@ public class TstConnector implements CreateOp, PoolableConnector, SchemaOp, Sear
 
     public static ObjectClass userObjectClass() {
         return new ObjectClass(USER_CLASS_NAME);
+    }
+
+
+    // Get only the parts of the schema which are requested by the IAM system.
+    @Override
+    public Schema getPartialSchema(LightweightObjectClassInfo... objectClassInfos) {
+
+        SchemaBuilder schemaBuilder = new SchemaBuilder(TstConnector.class);
+        Iterator<LightweightObjectClassInfo> iterator = Arrays.stream(objectClassInfos).iterator();
+
+        while (iterator.hasNext()) {
+
+            LightweightObjectClassInfo lightweightObjectClassInfo = iterator.next();
+            ObjectClassInfoBuilder objectClassInfoBuilder = new ObjectClassInfoBuilder();
+            String type = lightweightObjectClassInfo.getType();
+            objectClassInfoBuilder.setType(type);
+            objectClassInfoBuilder.setDescription(lightweightObjectClassInfo.getDescription());
+            objectClassInfoBuilder.setEmbedded(lightweightObjectClassInfo.isEmbedded());
+            objectClassInfoBuilder.setAuxiliary(lightweightObjectClassInfo.isAuxiliary());
+            objectClassInfoBuilder.setContainer(lightweightObjectClassInfo.isContainer());
+            objectClassInfoBuilder.addAllAttributeInfo(buildAttributeInfos(type));
+        }
+
+        return schemaBuilder.build();
+    }
+
+    private Collection<AttributeInfo> buildAttributeInfos(String type) {
+
+        Collection<AttributeInfo> attributeInfos = new ArrayList<>();
+        if (USER_CLASS_NAME.equals(type)) {
+
+            attributeInfos.add(
+                    new AttributeInfoBuilder(Uid.NAME, String.class)
+                            .setRequired(true)
+                            .setDescription(USER_CLASS_UID_DESCRIPTION)
+                            .build());
+            attributeInfos.add(
+                    new AttributeInfoBuilder(Name.NAME, String.class)
+                            .setRequired(true)
+                            .setDescription(USER_CLASS_NAME_DESCRIPTION)
+                            .build());
+            attributeInfos.add(
+                    new AttributeInfoBuilder(MEMBER_OF_ATTR_NAME, ConnectorObjectReference.class)
+                            .setReferencedObjectClassName(GROUP_CLASS_NAME)
+                            .setSubtype(GROUP_MEMBERSHIP_REFERENCE_TYPE_NAME)
+                            .setRoleInReference(RoleInReference.SUBJECT.toString())
+                            .setMultiValued(true)
+                            .setDescription(USER_CLASS_MEMBER_OF_DESCRIPTION)
+                            .build());
+            attributeInfos.add(
+                    new AttributeInfoBuilder(ACCESS_ATTR_NAME, ConnectorObjectReference.class)
+                            .setReferencedObjectClassName(ACCESS_CLASS_NAME)
+                            .setRoleInReference(RoleInReference.SUBJECT.toString())
+                            .setMultiValued(true)
+                            .setDescription(USER_CLASS_ACCESS_DESCRIPTION)
+                            .build());
+
+        } else if (GROUP_CLASS_NAME.equals(type)) {
+            attributeInfos.add(
+                    new AttributeInfoBuilder(Uid.NAME, String.class)
+                            .setRequired(true)
+                            .setDescription(GROUP_CLASS_UID_DESCRIPTION)
+                            .build());
+            attributeInfos.add(
+                    new AttributeInfoBuilder(Name.NAME, String.class)
+                            .setRequired(true)
+                            .setDescription(GROUP_CLASS_NAME_DESCRIPTION)
+                            .build());
+            attributeInfos.add(
+                    new AttributeInfoBuilder(MEMBERS_ATTR_NAME, ConnectorObjectReference.class)
+                            .setReferencedObjectClassName(USER_CLASS_NAME)
+                            .setSubtype(GROUP_MEMBERSHIP_REFERENCE_TYPE_NAME)
+                            .setRoleInReference(RoleInReference.OBJECT.toString())
+                            .setMultiValued(true)
+                            .setDescription(GROUP_CLASS_MEMBERS_ATTR_DESCRIPTION)
+                            .build());
+
+        } else if (ACCESS_CLASS_NAME.equals(type)) {
+
+            attributeInfos.add(
+                    new AttributeInfoBuilder(GROUP_ATTR_NAME, ConnectorObjectReference.class)
+                            .setReferencedObjectClassName(GROUP_CLASS_NAME)
+                            .setDescription(ACCESS_CLASS_ATTR_REFERENCE_DESCRIPTION)
+                            .build());
+
+        } else {
+            for (int j = 0; j < 200; j++) {
+                attributeInfos.add(AttributeInfoBuilder.build("attributename" + j, String.class));
+            }
+        }
+        return attributeInfos;
+    }
+
+    // Provide this to the IAM system to choose the object class information.
+    @Override
+    public LightweightObjectClassInfo[] getObjectClassInformation() {
+
+        ArrayList<LightweightObjectClassInfo> lightweightObjectClassInfos = new ArrayList<>();
+
+        for (int i = 0; i < 2; i++) {
+            lightweightObjectClassInfos.add(
+                    new LightweightObjectClassInfoBuilder()
+                            .setType("class" + i)
+                            .setDescription("Object class of the type class" + i)
+                            .build()
+            );
+        }
+        lightweightObjectClassInfos.add(
+                new LightweightObjectClassInfoBuilder()
+                        .setType(USER_CLASS_NAME)
+                        .setDescription(USER_CLASS_DESCRIPTION)
+                        .build());
+
+        lightweightObjectClassInfos.add(
+                new LightweightObjectClassInfoBuilder()
+                        .setType(GROUP_CLASS_NAME)
+                        .setDescription(GROUP_CLASS_DESCRIPTION)
+                        .build());
+        lightweightObjectClassInfos.add(
+                new LightweightObjectClassInfoBuilder()
+                        .setType(ACCESS_CLASS_NAME)
+                        .setEmbedded(true)
+                        .setDescription(ACCESS_CLASS_DESCRIPTION)
+                        .build());
+
+        return lightweightObjectClassInfos.toArray(new LightweightObjectClassInfo[0]);
     }
 }

--- a/java/testbundlev1/src/main/java/org/identityconnectors/testconnector/TstConnector.java
+++ b/java/testbundlev1/src/main/java/org/identityconnectors/testconnector/TstConnector.java
@@ -24,15 +24,22 @@
  */
 package org.identityconnectors.testconnector;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import org.identityconnectors.framework.common.objects.Attribute;
+import org.identityconnectors.framework.common.objects.AttributeInfo;
 import org.identityconnectors.framework.common.objects.AttributeInfo.RoleInReference;
 import org.identityconnectors.framework.common.objects.AttributeInfoBuilder;
 import org.identityconnectors.framework.common.objects.ConnectorObject;
 import org.identityconnectors.framework.common.objects.ConnectorObjectBuilder;
 import org.identityconnectors.framework.common.objects.ConnectorObjectReference;
+import org.identityconnectors.framework.common.objects.LightweightObjectClassInfo;
+import org.identityconnectors.framework.common.objects.LightweightObjectClassInfoBuilder;
 import org.identityconnectors.framework.common.objects.LiveSyncDeltaBuilder;
 import org.identityconnectors.framework.common.objects.LiveSyncResultsHandler;
 import org.identityconnectors.framework.common.objects.Name;


### PR DESCRIPTION
This PR introduces two schema-related improvements:
- **[BASE-97] Description fields**: Added `description` parameter to `AttributeInfo` and `ObjectClassInfo`
- **[BASE-98] Partial schema support**: Introduced partial schema API with `LightweightObjectClassInfo` and related SPI/API classes

## Changes

### BASE-97: Description fields
- Extended `AttributeInfo` and `ObjectClassInfo` with `description` parameter

### BASE-98: Partial schema
- Added `LightweightObjectClassInfo` and builder classes
- Introduced `PartialSchemaApiOp` SPI and API classes
- Serialization and deserialization support for description parameters
- Binary-level backwards compatibility for `ObjectClassInfoBuilder`
- Extended `FrameworkUtil` and `SchemaBuilder`, test coverage

[BASE-97]: https://connid.atlassian.net/browse/BASE-97?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BASE-98]: https://connid.atlassian.net/browse/BASE-98?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ