### PR TITLE
[BASE-99] Support for Low Code Connector (repackaged connectors) 

### DIFF
--- a/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/ConnectorBundleManifest.java
+++ b/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/ConnectorBundleManifest.java
@@ -34,6 +34,7 @@ public final class ConnectorBundleManifest {
     private String frameworkVersion;
     private String bundleName;
     private String bundleVersion;
+    private String connectorClass;
 
     public String getFrameworkVersion() {
         return frameworkVersion;
@@ -57,5 +58,13 @@ public final class ConnectorBundleManifest {
 
     public void setBundleVersion(String ver) {
         bundleVersion = ver;
+    }
+
+    public String getConnectorClass() {
+        return connectorClass;
+    }
+
+    public void setConnectorClass(String connectorClass) {
+        this.connectorClass = connectorClass;
     }
 }

--- a/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/ConnectorBundleManifestParser.java
+++ b/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/ConnectorBundleManifestParser.java
@@ -39,6 +39,7 @@ public final class ConnectorBundleManifestParser {
     private static final String ATT_BUNDLE_NAME = BUNDLE_PREFIX + "Name";
 
     private static final String ATT_BUNDLE_VERSION = BUNDLE_PREFIX + "Version";
+    private static final String ATT_CONNECTOR_CLASS = BUNDLE_PREFIX + "ConnectorClass";
 
     private final String fileName;
 
@@ -68,7 +69,7 @@ public final class ConnectorBundleManifestParser {
         String frameworkVersion = getRequiredAttribute(ATT_FRAMEWORK_VERSION);
         String bundleName = getRequiredAttribute(ATT_BUNDLE_NAME);
         String bundleVersion = getRequiredAttribute(ATT_BUNDLE_VERSION);
-
+        String connectorClass = getAttribute(ATT_CONNECTOR_CLASS);
         if (FrameworkUtil.getFrameworkVersion().compareTo(Version.parse(frameworkVersion)) < 0) {
             String message =
                     "Bundle " + fileName + " requests an unrecognized " + "framework version "
@@ -82,7 +83,7 @@ public final class ConnectorBundleManifestParser {
         rv.setFrameworkVersion(frameworkVersion);
         rv.setBundleName(bundleName);
         rv.setBundleVersion(bundleVersion);
-
+        rv.setConnectorClass(connectorClass);
         return rv;
     }
 

--- a/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/JavaClassProperties.java
+++ b/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/JavaClassProperties.java
@@ -30,6 +30,8 @@ import java.beans.BeanInfo;
 import java.beans.IndexedPropertyDescriptor;
 import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
+import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 import java.text.MessageFormat;
@@ -40,6 +42,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.Properties;
 import java.util.TreeSet;
 import org.identityconnectors.common.ReflectionUtil;
 import org.identityconnectors.common.StringUtil;
@@ -55,6 +58,7 @@ import org.identityconnectors.framework.spi.Configuration;
 import org.identityconnectors.framework.spi.ConfigurationClass;
 import org.identityconnectors.framework.spi.ConfigurationProperty;
 import org.identityconnectors.framework.spi.operations.SPIOperation;
+
 
 /**
  * Class for translating from a Java class to ConfigurationProperties and from
@@ -280,6 +284,16 @@ public class JavaClassProperties {
         if (null != options) {
             excludes.addAll(Arrays.asList(options.ignore()));
             filterUnsupported = options.skipUnsupported();
+
+            if (null != options.overrideFile() && !options.overrideFile().isEmpty()) {
+                Properties props = loadPropertiesOverrideFile(config, options.overrideFile());
+                for (String key : props.stringPropertyNames()) {
+                    String value = props.getProperty(key, null);
+                    if ("ignore".equals(value)) {
+                        excludes.add(key);
+                    }
+                }
+            }
         }
 
         for (PropertyDescriptor descriptor : descriptors) {
@@ -303,6 +317,19 @@ public class JavaClassProperties {
             rv.put(propName, descriptor);
         }
         return rv;
+    }
+
+    private static Properties loadPropertiesOverrideFile(Class<? extends Configuration> config, String resourcePath) {
+        Properties props = new Properties();
+        InputStream resource = config.getClassLoader().getResourceAsStream(resourcePath);
+        if (resource != null) {
+            try (resource) {
+                props.load(resource);
+            } catch (IOException e) {
+                // Silently ignoring
+            };
+        }
+        return props;
     }
 
     /**

--- a/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/LocalConnectorInfoManagerImpl.java
+++ b/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/local/LocalConnectorInfoManagerImpl.java
@@ -255,62 +255,89 @@ public class LocalConnectorInfoManagerImpl implements ConnectorInfoManager {
                         // However, we should definitely warn
                         LOG.info(LOG.isOk() ? e : null,
                                 "Unable to load class {0} from bundle {1}. Class will be ignored and will not be "
-                                + "listed in list of connectors.",
+                                        + "listed in list of connectors.",
                                 className, bundleInfo.getOriginalLocation());
                     }
-                    if (connectorClass != null && options == null) {
-                        for (Annotation annotation : connectorClass.getAnnotations()) {
-                            if (ConnectorClass.class.getName().equals(annotation.annotationType().getName())) {
-                                // Same class name as the annotation we are looking for. But the previous code haven't 
-                                // found it.
-                                // So it looks like the annotation on this class is actually the correct one but it is
-                                // loaded by wrong classloader.
-                                // Note: This error is very difficult to diagnose. Therefore we are explicitly checking 
-                                // for it here.
-                                throw new ConfigurationException("Class " + connectorClass.getName()
-                                        + " has ConnectorClass annotation but it looks like it is "
-                                        + "loaded by a wrong classloader. Maybe the connector bundle contains the "
-                                        + "connector frameworks JAR? (it should NOT contain it).");
-                            }
-                        }
-                    }
                 }
-                if (connectorClass != null && options != null) {
-                    if (!Connector.class.isAssignableFrom(connectorClass)) {
-                        throw new ConfigurationException("Class " + connectorClass
-                                + " does not implement " + Connector.class.getName());
-                    }
-                    final LocalConnectorInfoImpl info = new LocalConnectorInfoImpl();
-                    info.setConnectorClass(connectorClass.asSubclass(Connector.class));
-                    try {
-                        info.setConnectorConfigurationClass(options.configurationClass());
-                        info.setConnectorDisplayNameKey(options.displayNameKey());
-                        info.setConnectorCategoryKey(options.categoryKey());
-                        info.setConnectorKey(new ConnectorKey(bundleInfo.getManifest().getBundleName(),
-                                bundleInfo.getManifest().getBundleVersion(), connectorClass.getName()));
-                        final ConnectorMessagesImpl messages =
-                                loadMessageCatalog(bundleInfo.getEffectiveContents(), loader, info
-                                        .getConnectorClass());
-                        info.setMessages(messages);
-                        info.setDefaultAPIConfiguration(createDefaultAPIConfiguration(info));
-                        rv.add(info);
-                        LOG.info("Add ConnectorInfo {0} to Local Connector Info Manager from {1}",
-                                info.getConnectorKey(), bundleInfo.getOriginalLocation());
-                    } catch (final NoClassDefFoundError e) {
-                        LOG.info(LOG.isOk() ? e : null,
-                                "Unable to load configuration class of connector {0} from bundle {1}. "
-                                + "Class will be ignored and will not be listed in list of connectors.",
-                                connectorClass, bundleInfo.getOriginalLocation());
-                    } catch (final TypeNotPresentException e) {
-                        LOG.info(LOG.isOk() ? e : null,
-                                "Unable to load configuration class of connector {0} from bundle {1}. "
-                                + "Class will be ignored and will not be listed in list of connectors.",
-                                connectorClass, bundleInfo.getOriginalLocation());
-                    }
+                if (connectorClass != null) {
+                    addValidConnectorToList(bundleInfo, loader, connectorClass, options, rv);
                 }
             });
+            String className = bundleInfo.getManifest().getConnectorClass();
+            if (className != null) {
+                Class<?> connectorClass = null;
+                ConnectorClass options = null;
+                try {
+                    connectorClass = loader.loadClass(className);
+                    options = connectorClass.getAnnotation(ConnectorClass.class);
+                } catch (Throwable e) {
+                    // probe for the class. this might not be an error since
+                    // it might be from a bundle
+                    // fragment ( a bundle only included by other bundles ).
+                    // However, we should definitely warn
+                    LOG.info(LOG.isOk() ? e : null,
+                            "Unable to load class {0} from bundle {1}. Class will be ignored and will not be "
+                                    + "listed in list of connectors.",
+                            className, bundleInfo.getOriginalLocation());
+                }
+                if (connectorClass != null) {
+                    addValidConnectorToList(bundleInfo, loader, connectorClass, options, rv);
+                }
+            }
         });
         return rv;
+    }
+
+    private static void addValidConnectorToList(WorkingBundleInfo bundleInfo, ClassLoader loader, Class<?> connectorClass, ConnectorClass options, List<ConnectorInfo> rv) {
+        if (options == null) {
+            for (Annotation annotation : connectorClass.getAnnotations()) {
+                if (ConnectorClass.class.getName().equals(annotation.annotationType().getName())) {
+                    // Same class name as the annotation we are looking for. But the previous code haven't
+                    // found it.
+                    // So it looks like the annotation on this class is actually the correct one but it is
+                    // loaded by wrong classloader.
+                    // Note: This error is very difficult to diagnose. Therefore we are explicitly checking
+                    // for it here.
+                    throw new ConfigurationException("Class " + connectorClass.getName()
+                            + " has ConnectorClass annotation but it looks like it is "
+                            + "loaded by a wrong classloader. Maybe the connector bundle contains the "
+                            + "connector frameworks JAR? (it should NOT contain it).");
+                }
+            }
+        }
+        if (options != null) {
+            if (!Connector.class.isAssignableFrom(connectorClass)) {
+                throw new ConfigurationException("Class " + connectorClass
+                        + " does not implement " + Connector.class.getName());
+            }
+            final LocalConnectorInfoImpl info = new LocalConnectorInfoImpl();
+            info.setConnectorClass(connectorClass.asSubclass(Connector.class));
+            try {
+                info.setConnectorConfigurationClass(options.configurationClass());
+                info.setConnectorDisplayNameKey(options.displayNameKey());
+                info.setConnectorCategoryKey(options.categoryKey());
+                info.setConnectorKey(new ConnectorKey(bundleInfo.getManifest().getBundleName(),
+                        bundleInfo.getManifest().getBundleVersion(), connectorClass.getName()));
+                final ConnectorMessagesImpl messages =
+                        loadMessageCatalog(bundleInfo.getEffectiveContents(), loader, info
+                                .getConnectorClass());
+                info.setMessages(messages);
+                info.setDefaultAPIConfiguration(createDefaultAPIConfiguration(info));
+                rv.add(info);
+                LOG.info("Add ConnectorInfo {0} to Local Connector Info Manager from {1}",
+                        info.getConnectorKey(), bundleInfo.getOriginalLocation());
+            } catch (final NoClassDefFoundError e) {
+                LOG.info(LOG.isOk() ? e : null,
+                        "Unable to load configuration class of connector {0} from bundle {1}. "
+                                + "Class will be ignored and will not be listed in list of connectors.",
+                        connectorClass, bundleInfo.getOriginalLocation());
+            } catch (final TypeNotPresentException e) {
+                LOG.info(LOG.isOk() ? e : null,
+                        "Unable to load configuration class of connector {0} from bundle {1}. "
+                                + "Class will be ignored and will not be listed in list of connectors.",
+                        connectorClass, bundleInfo.getOriginalLocation());
+            }
+        }
     }
 
     /**

--- a/java/connector-framework-internal/src/test/java/org/identityconnectors/framework/impl/api/ConnectorInfoManagerTestBase.java
+++ b/java/connector-framework-internal/src/test/java/org/identityconnectors/framework/impl/api/ConnectorInfoManagerTestBase.java
@@ -23,13 +23,6 @@
  */
 package org.identityconnectors.framework.impl.api;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-
 import java.io.File;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -82,6 +75,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public abstract class ConnectorInfoManagerTestBase {
 
@@ -666,6 +661,21 @@ public abstract class ConnectorInfoManagerTestBase {
         } catch (OperationTimeoutException e) {
             //expected
         }
+    }
+
+    @Test
+    public void testCongifurationOverride() throws Exception {
+        ConnectorInfoManager manager = getConnectorInfoManager();
+        ConnectorInfo info = findConnectorInfo(manager,
+                "1.0.0.0",
+                "org.identityconnectors.testconnector.TstConnector");
+
+        APIConfiguration api = info.createDefaultAPIConfiguration();
+
+        ConfigurationProperties props = api.getConfigurationProperties();
+        ConfigurationProperty property = props.getProperty("hiddenField");
+        // Property should be hidden from configuration.
+        assertNull(property);
     }
 
     static File getTestBundlesDir() throws URISyntaxException {

--- a/java/connector-framework/src/main/java/org/identityconnectors/framework/spi/ConfigurationClass.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/framework/spi/ConfigurationClass.java
@@ -49,4 +49,11 @@ public @interface ConfigurationClass {
      * List of properties which should be excluded from configuration properties.
      */
     public String[] ignore() default {};
+
+    /**
+     * Optional Property file which overrides configuration property visibility.
+     *
+     * @return
+     */
+    String overrideFile() default "";
 }

--- a/java/testbundlev1/src/main/java/org/identityconnectors/testconnector/TstConnectorConfig.java
+++ b/java/testbundlev1/src/main/java/org/identityconnectors/testconnector/TstConnectorConfig.java
@@ -27,15 +27,18 @@ package org.identityconnectors.testconnector;
 import org.identityconnectors.common.l10n.CurrentLocale;
 import org.identityconnectors.framework.common.exceptions.ConnectorException;
 import org.identityconnectors.framework.spi.AbstractConfiguration;
+import org.identityconnectors.framework.spi.ConfigurationClass;
 import org.identityconnectors.framework.spi.ConfigurationProperty;
 import org.identityconnectors.framework.spi.operations.LiveSyncOp;
 import org.identityconnectors.framework.spi.operations.SyncOp;
 
+@ConfigurationClass(overrideFile = "TstConnectorConfig.override.properties")
 public class TstConnectorConfig extends AbstractConfiguration {
 
     private String tstField;
 
     private String tst1Field;
+    private String hiddenField;
 
     private int numResults;
 
@@ -104,5 +107,13 @@ public class TstConnectorConfig extends AbstractConfiguration {
         if (failValidation) {
             throw new ConnectorException("validation failed " + CurrentLocale.get().getLanguage());
         }
+    }
+
+    public String getHiddenField() {
+        return hiddenField;
+    }
+
+    public void setHiddenField(String tst2Field) {
+        this.hiddenField = tst2Field;
     }
 }

--- a/java/testbundlev1/src/main/resources/TstConnectorConfig.override.properties
+++ b/java/testbundlev1/src/main/resources/TstConnectorConfig.override.properties
@@ -1,0 +1,24 @@
+#
+# ====================
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+#
+# Copyright 2015 ConnId. All rights reserved.
+#
+# The contents of this file are subject to the terms of the Common Development
+# and Distribution License("CDDL") (the "License").  You may not use this file
+# except in compliance with the License.
+#
+# You can obtain a copy of the License at
+# http://opensource.org/licenses/cddl1.php
+# See the License for the specific language governing permissions and limitations
+# under the License.
+#
+# When distributing the Covered Code, include this CDDL Header Notice in each file
+# and include the License file at http://opensource.org/licenses/cddl1.php.
+# If applicable, add the following below this CDDL Header, with the fields
+# enclosed by brackets [] replaced by your own identifying information:
+# "Portions Copyrighted [year] [name of copyright owner]"
+# ====================
+#
+
+hiddenField=ignore


### PR DESCRIPTION
This PR adds support for low-code connectors (packaged scripted connectors) by introducing connector class specification in the manifest and a prototype configuration override mechanism.

## Changes

### BASE-99: Low-code connector
- Added support for specifying Connector class in the manifest
- Prototype implementation for configuration override
