### PR TITLE
[BASE-101] Key the managed connector facade cache on the ConnectorKey

### DIFF
--- a/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/ManagedConnectorFacadeFactoryImpl.java
+++ b/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/api/ManagedConnectorFacadeFactoryImpl.java
@@ -29,6 +29,7 @@ import org.identityconnectors.common.logging.Log;
 import org.identityconnectors.framework.api.APIConfiguration;
 import org.identityconnectors.framework.api.ConnectorFacade;
 import org.identityconnectors.framework.api.ConnectorInfo;
+import org.identityconnectors.framework.api.ConnectorKey;
 import org.identityconnectors.framework.impl.api.local.LocalConnectorFacadeImpl;
 
 public class ManagedConnectorFacadeFactoryImpl extends ConnectorFacadeFactoryImpl {
@@ -46,7 +47,9 @@ public class ManagedConnectorFacadeFactoryImpl extends ConnectorFacadeFactoryImp
     @Override
     public ConnectorFacade newInstance(final APIConfiguration config) {
         ConnectorFacade facade = super.newInstance(config);
-        ConnectorFacade ret = CACHE.putIfAbsent(facade.getConnectorFacadeKey(), facade);
+        final ConnectorKey connectorKey = ((APIConfigurationImpl) config).getConnectorInfo().getConnectorKey();
+        String cacheKey = cacheKey(connectorKey, facade.getConnectorFacadeKey());
+        ConnectorFacade ret = CACHE.putIfAbsent(cacheKey, facade);
         if (null != ret) {
             LOG.ok("ConnectorFacade found in cache");
             facade = ret;
@@ -57,17 +60,31 @@ public class ManagedConnectorFacadeFactoryImpl extends ConnectorFacadeFactoryImp
 
     @Override
     public ConnectorFacade newInstance(final ConnectorInfo connectorInfo, String config) {
-        ConnectorFacade facade = CACHE.get(config);
+        final String cacheKey = cacheKey(connectorInfo.getConnectorKey(), config);
+        ConnectorFacade facade = CACHE.get(cacheKey);
         if (null == facade) {
             // new ConnectorFacade creation must remain cheap operation
             facade = super.newInstance(connectorInfo, config);
-            ConnectorFacade ret = CACHE.putIfAbsent(facade.getConnectorFacadeKey(), facade);
+            ConnectorFacade ret = CACHE.putIfAbsent(cacheKey, facade);
             if (null != ret) {
                 LOG.ok("ConnectorFacade found in cache");
                 facade = ret;
             }
         }
         return facade;
+    }
+
+    /**
+     * Identifies a cached facade by its bundle version as well as by its configuration.
+     * <p>
+     * The configuration alone is not enough. It is serialized without the ConnectorInfo, so two versions of the same
+     * connector carrying the same configuration produce the same connector facade key, and the version that was
+     * looked up first would answer for both: an operation would silently run the code of a bundle it did not select.
+     * Including the ConnectorKey lets several versions of one bundle be installed side by side and still be told
+     * apart. A local and a remote ConnectorInfo sharing a ConnectorKey still map to the same entry.
+     */
+    private static String cacheKey(final ConnectorKey connectorKey, final String connectorFacadeKey) {
+        return connectorKey.toString() + '\n' + connectorFacadeKey;
     }
 
     /**

--- a/java/connector-framework-internal/src/test/java/org/identityconnectors/framework/impl/api/ManagedConnectorFacadeFactoryTests.java
+++ b/java/connector-framework-internal/src/test/java/org/identityconnectors/framework/impl/api/ManagedConnectorFacadeFactoryTests.java
@@ -1,0 +1,101 @@
+/*
+ * ====================
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright 2008-2009 Sun Microsystems, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Common Development
+ * and Distribution License("CDDL") (the "License").  You may not use this file
+ * except in compliance with the License.
+ *
+ * You can obtain a copy of the License at
+ * http://opensource.org/licenses/cddl1.php
+ * See the License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * When distributing the Covered Code, include this CDDL Header Notice in each file
+ * and include the License file at http://opensource.org/licenses/cddl1.php.
+ * If applicable, add the following below this CDDL Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyrighted [year] [name of copyright owner]"
+ * ====================
+ * Portions Copyrighted 2018 ConnId
+ */
+package org.identityconnectors.framework.impl.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.identityconnectors.framework.api.ConnectorFacade;
+import org.identityconnectors.framework.api.ConnectorFacadeFactory;
+import org.identityconnectors.framework.api.ConnectorKey;
+import org.identityconnectors.framework.impl.api.local.LocalConnectorInfoImpl;
+import org.identityconnectors.framework.impl.api.local.LocalConnectorInfoManagerImpl;
+import org.identityconnectors.mockconnector.MockConfiguration;
+import org.identityconnectors.mockconnector.MockConnector;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+public class ManagedConnectorFacadeFactoryTests {
+
+    private static final String BUNDLE_NAME = "org.identityconnectors.mockconnector.bundle";
+
+    @AfterEach
+    public void clearFacadeCache() {
+        ConnectorFacadeFactory.getManagedInstance().dispose();
+    }
+
+    /**
+     * Two versions of one bundle installed side by side, configured identically. They share a connector facade key,
+     * because that key is the serialized APIConfiguration and the ConnectorInfo is deliberately left out of it, so the
+     * cache has to tell them apart by something else. Handing the second one the facade built for the first means an
+     * operation runs the code of a bundle it did not select.
+     */
+    @Test
+    public void versionsOfTheSameBundleDoNotShareAFacade() {
+        LocalConnectorInfoImpl olderVersion = connectorInfo("1.0.0.0");
+        LocalConnectorInfoImpl newerVersion = connectorInfo("2.0.0.0");
+
+        String sharedFacadeKey = connectorFacadeKeyOf(olderVersion);
+        assertEquals(sharedFacadeKey, connectorFacadeKeyOf(newerVersion),
+                "the two versions must be indistinguishable by facade key for this test to mean anything");
+
+        ConnectorFacadeFactory factory = ConnectorFacadeFactory.getManagedInstance();
+        ConnectorFacade olderFacade = factory.newInstance(olderVersion, sharedFacadeKey);
+        ConnectorFacade newerFacade = factory.newInstance(newerVersion, sharedFacadeKey);
+
+        assertNotSame(olderFacade, newerFacade,
+                "each bundle version must get its own facade, otherwise the version used first answers for both");
+    }
+
+    @Test
+    public void oneBundleVersionReusesItsCachedFacade() {
+        LocalConnectorInfoImpl connectorInfo = connectorInfo("1.0.0.0");
+        String facadeKey = connectorFacadeKeyOf(connectorInfo);
+
+        ConnectorFacadeFactory factory = ConnectorFacadeFactory.getManagedInstance();
+
+        assertSame(factory.newInstance(connectorInfo, facadeKey),
+                factory.newInstance(connectorInfo, facadeKey),
+                "the same bundle version and configuration should still be served from the cache");
+    }
+
+    private static String connectorFacadeKeyOf(LocalConnectorInfoImpl connectorInfo) {
+        return ConnectorFacadeFactory.getInstance()
+                .newInstance(connectorInfo.createDefaultAPIConfiguration())
+                .getConnectorFacadeKey();
+    }
+
+    private static LocalConnectorInfoImpl connectorInfo(String bundleVersion) {
+        LocalConnectorInfoImpl info = new LocalConnectorInfoImpl();
+        info.setConnectorClass(MockConnector.class);
+        info.setConnectorConfigurationClass(MockConfiguration.class);
+        info.setConnectorDisplayNameKey("DUMMY_DISPLAY_NAME");
+        info.setConnectorKey(new ConnectorKey(BUNDLE_NAME, bundleVersion, MockConnector.class.getName()));
+        info.setMessages(new ConnectorMessagesImpl());
+
+        info.setDefaultAPIConfiguration(LocalConnectorInfoManagerImpl.createDefaultAPIConfiguration(info));
+        return info;
+    }
+}


### PR DESCRIPTION
`ManagedConnectorFacadeFactoryImpl` caches connector facades under the connector facade key alone:

```java
public ConnectorFacade newInstance(final ConnectorInfo connectorInfo, String config) {
    ConnectorFacade facade = CACHE.get(config);
    ...
}
```

That key is the serialized `APIConfiguration`, and `AbstractConnectorFacade` deliberately leaves the `ConnectorInfo` out of it:

```java
byte[] bytes = SerializerUtil.serializeBinaryObject(configuration);
connectorFacadeKey = Base64.getEncoder().encodeToString(bytes);
this.configuration = (APIConfigurationImpl) SerializerUtil.deserializeBinaryObject(bytes);
// parent ref not included in the clone
this.configuration.setConnectorInfo(configuration.getConnectorInfo());
```

So two versions of the same bundle, configured identically, produce the same key. `newInstance(ConnectorInfo, String)` returns the cached facade without ever consulting the `ConnectorInfo` it was handed, and whichever version was looked up first answers for both — an operation silently runs the code of a bundle it did not select, bound to that bundle's class loader.

### How it shows up

Installing a newer version of a connector alongside the old one and repointing a resource at it appears to have no effect. Changing only the bundle version leaves every configuration property untouched, so the facade key is unchanged and the old bundle keeps answering. It can also look intermittent: nothing on disk changes, but whichever resource happens to run first after a restart decides which version everyone gets.

`ConnectorInfo.getConnectorKey()` reports the version that was requested — it comes from the manifest of the bundle the framework picked — so the mix-up is invisible from the API side.

### The change

Include the `ConnectorKey` in the cache key. Several versions of one bundle can then be installed side by side and still be told apart, while facades for the same version and configuration are still shared. A local and a remote `ConnectorInfo` sharing a `ConnectorKey` still map to the same entry.

Both `newInstance` overloads use the same composition so the two entry points agree.

### Test

`ManagedConnectorFacadeFactoryTests` covers both directions:

- `versionsOfTheSameBundleDoNotShareAFacade` — two `ConnectorInfo`s differing only in bundle version must get distinct facades. It first asserts the two share a connector facade key, so the test keeps its meaning if that ever changes.
- `oneBundleVersionReusesItsCachedFacade` — caching still works for the same version and configuration.

Reverting the fix makes the first fail with:

```
expected: not same but was: <org.identityconnectors.framework.impl.api.local.LocalConnectorFacadeImpl@27ff5d15>
```

### Verification

Verified on the `1_6_X_Y` branch and on the `connid-1.6.1.1` tag, where the touched file is byte-identical to `master`. I was not able to build `master` locally because `net.tirasa:groovy-security-sandbox:1.1.0-SNAPSHOT` is not resolvable through the artifact mirror I have available, so CI will be the first build of it on this branch.
